### PR TITLE
Add a simple test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,11 @@
   "engines": { "node": ">=0.8.3" },
   "keywords": [ "ssh", "ssh2", "sftp", "secure", "shell", "scp", "client" ],
   "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/ssh2/raw/master/LICENSE" } ],
-  "repository" : { "type": "git", "url": "http://github.com/mscdex/ssh2.git" }
+  "repository" : { "type": "git", "url": "http://github.com/mscdex/ssh2.git" },
+  "devDependencies": {
+    "assert-called": "0.1.x"
+  },
+  "scripts": {
+    "test": "test/run"
+  }
 }

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -1,0 +1,40 @@
+var fs = require('fs'),
+    path = require('path'),
+    assert = require('assert'),
+    assertCalled = require('assert-called'),
+    ssh2 = require('../');
+
+var c = new ssh2();
+
+c.connect({
+  host: 'localhost',
+  port: 22,
+  username: process.env.USER,
+  privateKey: fs.readFileSync(process.env.HOME + '/.ssh/id_rsa'),
+  publicKey: fs.readFileSync(process.env.HOME + '/.ssh/id_rsa.pub')
+});
+
+c.on('ready', assertCalled(function () {
+  c.exec(
+    path.join(__dirname, 'fixtures', 'print-and-exit'),
+    assertCalled(function (err, stream) {
+      var data = '';
+
+      assert(!err);
+
+      stream.on('data', function (chunk, extended) {
+        assert(!extended);
+        data += chunk.toString('utf8');
+      });
+
+      stream.on('exit', assertCalled(function (code, signal) {
+        assert.equal(code, 42);
+        assert(!signal);
+
+        assert.equal(data, 'Hello, world\n');
+
+        c.end();
+      }));
+    })
+  );
+}));

--- a/test/fixtures/print-and-exit
+++ b/test/fixtures/print-and-exit
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Hello, world"
+exit 42

--- a/test/run
+++ b/test/run
@@ -1,0 +1,36 @@
+#!/bin/sh
+echo "Running test suite"
+
+passed=0
+failed=0
+total=0
+
+for t in test/*-test.js; do
+  total=`expr $total + 1`
+
+  echo
+
+  echo "Running $t..."
+  output=`node $t`
+  code=$?
+  if [ $code -ne 0 ]; then
+    failed=`expr $failed + 1`
+
+    echo $output
+    echo "  $(tput setaf 1)✗ $t (exit code: $code)$(tput sgr0)"
+  else
+    passed=`expr $passed + 1`
+
+    echo "  $(tput setaf 2)✓ $t $(tput sgr0)"
+  fi
+done
+
+echo
+
+if [ $failed -eq 0 ]; then
+  echo "$(tput setaf 2)✓ OK » $passed passed$(tput sgr0)"
+else
+  echo "$(tput setaf 1)✗ Failed » $failed failed$(tput sgr0)"
+  echo "$(tput setaf 2)           $passed passed$(tput sgr0)"
+  exit 1
+fi


### PR DESCRIPTION
This test executes a remote command and checks if output and exit code
is reported correctly.

Please note: you need your key in `authorized_keys` to make it work.
