### PR TITLE
Fix incorrect 'this' pointer to correct pointer ('self') in close() function for ReadStream

### DIFF
--- a/lib/SFTP/SFTPv3.js
+++ b/lib/SFTP/SFTPv3.js
@@ -1219,7 +1219,7 @@ ReadStream.prototype.destroy = function(cb) {
   this.readable = false;
 
   function close() {
-    this.buffer = undefined;
+    self.buffer = undefined;
     self._sftp.close(self.handle, function(err) {
       if (err) {
         cb && cb(err);


### PR DESCRIPTION
I caught this bug when testing my app with Mocha (global leak on 'buffer'). 
