### PR TITLE
Fix event listener leak with 'drain' event on connection object

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -62,7 +62,7 @@ function Channel(info, conn) {
       var stream = self._stream;
       self._stream = undefined;
       stream.emit('close');
-      conn.removeListener('drain', _onDrain);
+      conn.removeListener('drain', onDrain);
     }
   });
 


### PR DESCRIPTION
When a channel stream is created a handler for connection 'drain' event is added but is never removed.  Over time, as more channels are created we are noticing that this is producing a leak warning.
