### PR TITLE
Add file type information to stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ sftp.createReadStream('sample.txt', {start: 90, end: 99});
 
 * **write**(< _Buffer_ >handle, < _Buffer_ >buffer, < _integer_ >offset, < _integer_ >length, < _integer_ >position, < _function_ >callback) - _(void)_ - Writes `length` bytes from `buffer` starting at `offset` to the resource associated with `handle` starting at `position`. `callback` has 1 parameter: < _Error_ >err.
 
-* **fstat**(< _Buffer_ >handle, < _function_ >callback) - _(void)_ - Retrieves attributes for the resource associated with `handle`. `callback` has 2 parameters: < _Error_ >err, < _ATTRS_ >attributes.
+* **fstat**(< _Buffer_ >handle, < _function_ >callback) - _(void)_ - Retrieves attributes for the resource associated with `handle`. `callback` has 2 parameters: < _Error_ >err, < _Stats_ >stats.
 
 * **fsetstat**(< _Buffer_ >handle, < _ATTRS_ >attributes, < _function_ >callback) - _(void)_ - Sets the attributes defined in `attributes` for the resource associated with `handle`. `callback` has 1 parameter: < _Error_ >err.
 
@@ -513,9 +513,9 @@ sftp.createReadStream('sample.txt', {start: 90, end: 99});
 
 * **rmdir**(< _string_ >path, < _function_ >callback) - _(void)_ - Removes the directory at `path`. `callback` has 1 parameter: < _Error_ >err.
 
-* **stat**(< _string_ >path, < _function_ >callback) - _(void)_ - Retrieves attributes for `path`. `callback` has 2 parameter: < _Error_ >err, < _ATTRS_ >attributes.
+* **stat**(< _string_ >path, < _function_ >callback) - _(void)_ - Retrieves attributes for `path`. `callback` has 2 parameter: < _Error_ >err, < _Stats_ >stats.
 
-* **lstat**(< _string_ >path, < _function_ >callback) - _(void)_ - Retrieves attributes for `path`. If `path` is a symlink, the link itself is stat'ed instead of the resource it refers to. `callback` has 2 parameters: < _Error_ >err, < _ATTRS_ >attributes.
+* **lstat**(< _string_ >path, < _function_ >callback) - _(void)_ - Retrieves attributes for `path`. If `path` is a symlink, the link itself is stat'ed instead of the resource it refers to. `callback` has 2 parameters: < _Error_ >err, < _Stats_ >stats.
 
 * **setstat**(< _string_ >path, < _ATTRS_ >attributes, < _function_ >callback) - _(void)_ - Sets the attributes defined in `attributes` for `path`. `callback` has 1 parameter: < _Error_ >err.
 
@@ -555,6 +555,19 @@ When supplying an ATTRS object to one of the SFTP methods:
 
 * `permissions` can either be an integer or a string containing an octal number.
 
+
+Stats
+-----
+
+An object with the same attributes as an ATTRS object with the addition of the following methods:
+
+* `stats.isDirectory()`
+* `stats.isFile()`
+* `stats.isBlockDevice()`
+* `stats.isCharacterDevice()`
+* `stats.isSymbolicLink()`
+* `stats.isFIFO()`
+* `stats.isSocket()`
 
 Pseudo-TTY settings
 -------------------

--- a/lib/SFTP/SFTPv3.js
+++ b/lib/SFTP/SFTPv3.js
@@ -1,7 +1,8 @@
 var EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
     isDate = require('util').isDate,
-    Stream = require('stream');
+    Stream = require('stream'),
+    Stats = require('./Stats');
 
 var MAX_REQID = Math.pow(2, 32) - 1,
     VERSION_BUFFER = new Buffer([0, 0, 0, 5 /* length */,
@@ -1072,7 +1073,7 @@ SFTP.prototype._readAttrs = function(chunk) {
   */
   var data = this._data;
   if (!data._attrs)
-    data._attrs = {};
+    data._attrs = new Stats();
 
   if (typeof data._flags !== 'number')
     data._flags = this._readUInt32BE(chunk);

--- a/lib/SFTP/Stats.js
+++ b/lib/SFTP/Stats.js
@@ -1,0 +1,38 @@
+
+var constants = process.binding('constants');
+
+module.exports = Stats;
+
+function Stats(){}
+
+Stats.prototype._checkModeProperty = function(property) {
+  return ((this.permissions & constants.S_IFMT) === property);
+};
+
+Stats.prototype.isDirectory = function() {
+  return this._checkModeProperty(constants.S_IFDIR);
+};
+
+Stats.prototype.isFile = function() {
+  return this._checkModeProperty(constants.S_IFREG);
+};
+
+Stats.prototype.isBlockDevice = function() {
+  return this._checkModeProperty(constants.S_IFBLK);
+};
+
+Stats.prototype.isCharacterDevice = function() {
+  return this._checkModeProperty(constants.S_IFCHR);
+};
+
+Stats.prototype.isSymbolicLink = function() {
+  return this._checkModeProperty(constants.S_IFLNK);
+};
+
+Stats.prototype.isFIFO = function() {
+  return this._checkModeProperty(constants.S_IFIFO);
+};
+
+Stats.prototype.isSocket = function() {
+  return this._checkModeProperty(constants.S_IFSOCK);
+};


### PR DESCRIPTION
I'm curious wether is would be possible to add a property telling us the file type in the stat command. I need to know wether it match a file, a directory or a link. Looking at the source code, I see that you have prepare the ground for a mechanism to retrieve extended attributes inside which i could find what I need. However, I also realized it would be hard for me to implement the feature. Hope you find the time to work on it. 
Thanks for your work, d.
