### PR TITLE
Improve fastxfer

### DIFF
--- a/lib/SFTP/SFTPv3.js
+++ b/lib/SFTP/SFTPv3.js
@@ -265,9 +265,8 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
         if (--left === 0)
           cb(err);
       };
-    } else {
-      cb(err)
-    }
+    } else
+      cb(err);
     if (srcfd) {
       ++left;
       fs.close(srcfd, cbfinal);
@@ -290,54 +289,51 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
         if (err) return onerror(err);
         dstfd = destfd;
 
-        if (fsize <= 0) {
-          cb()
-        } else {
-          function onread(err, nb, data, dstpos, datapos) {
+        if (fsize <= 0) return cb();
+        function onread(err, nb, data, dstpos, datapos) {
+          if (err) return onerror(err);
+
+          dst.write(destfd, data, datapos || 0, nb, dstpos, function(err) {
             if (err) return onerror(err);
 
-            dst.write(destfd, data, datapos || 0, nb, dstpos, function(err) {
-              if (err) return onerror(err);
-
-              if (--reads === 0) {
-                if (total === fsize) {
-                  dst.close(destfd, function(err) {
-                    dstfd = undefined;
+            if (--reads === 0) {
+              if (total === fsize) {
+                dst.close(destfd, function(err) {
+                  dstfd = undefined;
+                  if (err) return onerror(err);
+                  src.close(sourcefd, function(err) {
+                    srcfd = undefined;
                     if (err) return onerror(err);
-                    src.close(sourcefd, function(err) {
-                      srcfd = undefined;
-                      if (err) return onerror(err);
-                      cb();
-                    });
+                    cb();
                   });
-                } else
-                  read();
-              }
-            });
-            total += nb;
-          }
-
-          function makeCb(psrc, pdst) {
-            return function(err, nb, data) {
-              onread(err, nb, data, pdst, psrc);
-            };
-          }
-
-          function read() {
-            while (pdst < fsize && reads < concurrency) {
-              chunk = (pdst + chunkSize > fsize ? fsize - pdst : chunkSize);
-              if (src === fs)
-                src.read(sourcefd, readbuf, psrc, chunk, pdst, makeCb(psrc, pdst));
-              else
-                src.read(sourcefd, readbuf, psrc, chunk, pdst, onread);
-              psrc += chunk;
-              pdst += chunk;
-              ++reads;
+                });
+              } else
+                read();
             }
-            psrc = 0;
-          }
-          read();
+          });
+          total += nb;
         }
+
+        function makeCb(psrc, pdst) {
+          return function(err, nb, data) {
+            onread(err, nb, data, pdst, psrc);
+          };
+        }
+
+        function read() {
+          while (pdst < fsize && reads < concurrency) {
+            chunk = (pdst + chunkSize > fsize ? fsize - pdst : chunkSize);
+            if (src === fs)
+              src.read(sourcefd, readbuf, psrc, chunk, pdst, makeCb(psrc, pdst));
+            else
+              src.read(sourcefd, readbuf, psrc, chunk, pdst, onread);
+            psrc += chunk;
+            pdst += chunk;
+            ++reads;
+          }
+          psrc = 0;
+        }
+        read();
       });
     });
   });


### PR DESCRIPTION
- perform callback with err when `srcPath` and `dstPath` do not exist ( i.e. when trying to fastGet a file that does note exist)
- handle `fastXfer` of an empty file
