### PR TITLE
Fix env buffer

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -368,14 +368,14 @@ Channel.prototype._sendEnv = function(env) {
       buf.writeUInt32BE(this.outgoing.id, 1, true);
       buf.writeUInt32BE(3, 5, true);
       buf.write('env', 9, 3, 'ascii');
-      buf[13] = 0;
-      buf.writeUInt32BE(klen, 14, true);
-      buf.write(keys[i], 18, klen, 'ascii');
-      buf.writeUInt32BE(vlen, 18 + klen, true);
+      buf[12] = 0;
+      buf.writeUInt32BE(klen, 13, true);
+      buf.write(keys[i], 17, klen, 'ascii');
+      buf.writeUInt32BE(vlen, 17 + klen, true);
       if (Buffer.isBuffer(env[keys[i]]))
-        env[keys[i]].copy(buf, 18 + klen + 4);
+        env[keys[i]].copy(buf, 17 + klen + 4);
       else
-        buf.write(env[keys[i]], 18 + klen + 4, vlen, 'utf8');
+        buf.write(env[keys[i]], 17 + klen + 4, vlen, 'utf8');
       ret = this._conn._send(buf);
     }
     return ret;


### PR DESCRIPTION
This pull request is written after issue #54. After looking at the code, I realized that the buffer offset seems incorrect. After this change, there is no more error and the exec command return. 

However, I would exect the `env` command to print the "http_proxy" in this example:

``` js
c = new Connection()
c.on 'ready', () ->
  c.exec 'env', {env:{http_proxy:'test'}}, (err, stream) ->
    stream.on 'data', (data, extended) ->
      console.log data.toString()
    stream.on 'exit', (code, signal) ->
      c.end()
```
