### PR TITLE
Term value should be string, not number

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1335,7 +1335,7 @@ Connection.prototype._reqPty = function(chan, opts, cb) {
       width = opts.width;
     if (typeof opts.height === 'number')
       height = opts.height;
-    if (typeof opts.term === 'number')
+    if (typeof opts.term === 'string')
       term = opts.term;
   } else if (typeof opts === 'function')
     cb = opts;


### PR DESCRIPTION
Right now its always going to be `vt100`
