### PR TITLE
Added step callback for SFTP.fast(Get|Put)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ c.connect({
 // Vary: Accept-Encoding
 // Connection: close
 // Content-Type: text/html; charset=UTF-8
-// 
-// 
+//
+//
 // TCP :: EOF
 // TCP :: CLOSED
 // Connection :: end
@@ -384,7 +384,7 @@ Connection methods
     * **privateKey** - < _mixed_ > - Buffer or string that contains a private key for key-based user authentication (OpenSSH format). **Default:** (none)
 
     * **passphrase** - < _string_ > - For an encrypted private key, this is the passphrase used to decrypt it. **Default:** (none)
-    
+
     * **publicKey** - < _mixed_ > - Optional Buffer or string that contains a public key for key-based user authentication (OpenSSH format). If `publicKey` is not set, it will be generated from the `privateKey`. **Default:** (none)
 
     * **tryKeyboard** - < _boolean_ > - Try keyboard-interactive user authentication if primary user authentication method fails. **Default:** false
@@ -465,6 +465,8 @@ SFTP methods
 
     * chunkSize - _integer_ - Size of each read in bytes (default: 32768)
 
+    * step - _function_(< _Number_ >total_transferred, < _Number_ >chunk, < _Number_ >total) - Called every time a part of a file was transferred
+
     `callback` has 1 parameter: < _Error_ >err.
 
 * **fastPut**(< _string_ >localPath, < _string_ >remotePath[, < _object_ >options], < _function_ >callback) - _(void)_ - Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput. `options` has the following defaults:
@@ -472,6 +474,8 @@ SFTP methods
     * concurrency - _integer_ - Number of concurrent reads (default: 25)
 
     * chunkSize - _integer_ - Size of each read in bytes (default: 32768)
+
+    * step - _function_(< _Number_ >total_transferred, < _Number_ >chunk, < _Number_ >total) - Called every time a part of a file was transferred
 
     `callback` has 1 parameter: < _Error_ >err.
 

--- a/lib/SFTP/SFTPv3.js
+++ b/lib/SFTP/SFTPv3.js
@@ -240,7 +240,7 @@ SFTP.prototype.write = function(handle, buffer, offset, length, position, cb) {
 };
 
 function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
-  var concurrency = 25, chunkSize = 32768;
+  var concurrency = 25, chunkSize = 32768, step;
 
   if (typeof opts === 'function')
     cb = opts;
@@ -251,10 +251,12 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
     if (typeof opts.chunkSize === 'number' && opts.chunkSize > 0
         && !isNaN(opts.chunkSize))
       chunkSize = opts.chunkSize;
+    if (typeof opts.step === 'function')
+      step = opts.step;
   }
 
   // internal state variables
-  var fsize, chunk, psrc = 0, pdst = 0, reads = 0, total = 0, srcfd, dstfd,
+  var fsize, chunk, psrc = 0, pdst = 0, reads = 0, total = 0, srcfd, dstfd, total_done = 0,
       readbuf = new Buffer(chunkSize * concurrency);
 
   function onerror(err) {
@@ -277,6 +279,11 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
     }
   }
 
+  function onstep(chunk, total) {
+    total_done += chunk;
+    !!step&&step(total_done, chunk, total);
+  }
+
   src.stat(srcPath, function(err, attrs) {
     if (err) return onerror(err);
     fsize = attrs.size;
@@ -296,6 +303,8 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
           dst.write(destfd, data, datapos || 0, nb, dstpos, function(err) {
             if (err) return onerror(err);
 
+            onstep(nb, fsize);
+
             if (--reads === 0) {
               if (total === fsize) {
                 dst.close(destfd, function(err) {
@@ -307,8 +316,9 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
                     cb();
                   });
                 });
-              } else
+              } else {
                 read();
+              }
             }
           });
           total += nb;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "ssh2",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "An SSH2 client module written in pure JavaScript for node.js",
   "main": "./lib/Connection",


### PR DESCRIPTION
An ability to specify a step callback for file transfers can be useful when working with bigger files.
