### PR TITLE
Support for ref/unref

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1649,6 +1649,20 @@ Connection.prototype.end = function() {
     this._sock.destroy();
 };
 
+Connection.prototype.ref = function() {
+  if (this._sock && this._sock.ref)
+    this._sock.ref();
+  if (this._pinger && this._pinger.ref)
+    this._pinger.ref();
+};
+
+Connection.prototype.unref = function() {
+  if (this._sock && this._sock.unref)
+    this._sock.unref();
+  if (this._pinger && this._pinger.unref)
+    this._pinger.unref();
+};
+
 Connection.prototype._openChan = function(type, blob, cb) {
   // ask the server to open a channel for some purpose (e.g. session (sftp, exec,
   // terminal), or forwarding a TCP connection to the server)


### PR DESCRIPTION
This PR adds `.ref()` and `.unref()` support to the Connection prototype to easily deference the ssh connection from the event loop. The methods just forwards to `._sock` and `._pinger`.
