### PR TITLE
Fix missing drain when return value of write is undefined

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -607,7 +607,7 @@ ChannelStream.prototype._drainOutBuffer = function() {
     ret = false;
   }
 
-  if (ret)
+  if (ret !== false)
     this.emit('drain');
 
   return ret;


### PR DESCRIPTION
Hi. This fixes an issue I've been having where a `forwardOut` stream would suddenly not emit `drain`.
After some debugging I found out that it's because the `_drainOutBuffer` method on the `ChannelStream` didn't emit `drain` when a write returned undefined. This PR fixes this by emitting `drain` for all return values of write except false.
