### PR TITLE
Fixed `unforwardIn` function

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -640,7 +640,7 @@ Connection.prototype._reqX11 = function(chan, screen, cb) {
   chan._sendX11(cfg, function(err) {
     if (err)
       return cb(err);
-    
+
     cb();
   });
 };
@@ -718,14 +718,14 @@ Connection.prototype.unforwardIn = function(address, port, cb) {
   */
   var self = this,
       addrlen = Buffer.byteLength(address),
-      buf = new Buffer(1 + 4 + 13 + 1 + 4 + addrlen + 4);
+      buf = new Buffer(1 + 4 + 20 + 1 + 4 + addrlen + 4);
   buf[0] = MESSAGE.GLOBAL_REQUEST;
-  buf.writeUInt32BE(13, 1, true);
-  buf.write('cancel-tcpip-forward', 5, 13, 'ascii');
-  buf[18] = 1;
-  buf.writeUInt32BE(addrlen, 19, true);
-  buf.write(address, 23, addrlen, 'ascii');
-  buf.writeUInt32BE(port, 23 + addrlen, true);
+  buf.writeUInt32BE(20, 1, true);
+  buf.write('cancel-tcpip-forward', 5, 20, 'ascii');
+  buf[25] = 1;
+  buf.writeUInt32BE(addrlen, 26, true);
+  buf.write(address, 30, addrlen, 'ascii');
+  buf.writeUInt32BE(port, 30 + addrlen, true);
 
   this._callbacks.push(function(had_err) {
     if (had_err)


### PR DESCRIPTION
`unforwardIn` didn't work, because it used to send only the first 13 characters of "cancel-tcpip-forward", which is "cancel-tcpip-". None of the servers understood this.

So I fixed it.

And by the way, when I saw the code, I was a little bit shocked when I saw these things repeating over and over:

```
buf = new Buffer(1 + 4 + 20 + 1 + 4 + addrlen + 4);
buf[0] = MESSAGE.GLOBAL_REQUEST;
buf.writeUInt32BE(20, 1, true);
buf.write('cancel-tcpip-forward', 5, 20, 'ascii');
buf[25] = 1;
buf.writeUInt32BE(addrlen, 26, true);
buf.write(address, 30, addrlen, 'ascii');
buf.writeUInt32BE(port, 30 + addrlen, true);
```

As you can see, this pattern is very error-prone.

Why don't you create a buffer class and then refactor the code like this:

```
buf = new SSHBuffer();
buf.addByte(MESSAGE.GLOBAL_REQUEST);
buf.addUInt32BE(20);
buf.addString('cancel-tcpip-forward');
buf.addByte(1);
buf.addUInt32BE(addrlen);
buf.addString(address);
buf.addUInt32BE(port);
buf = buf.toNodeBuffer();
```

Even OpenSSH implementation, written in pure C has this kind of abstraction.
