### PR TITLE
Channel: fix undefined property

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -751,9 +751,9 @@ ChannelStream.prototype.destroy = function() {
   if (this._channel) {
     ret = this._channel.eof();
     ret = this._channel.close();
+    if (this._channel._hasX11)
+      --this._channel._conn._acceptX11;
   }
-  if (this._channel._hasX11)
-    --this._channel._conn._acceptX11;
   this._cleanup();
   return ret;
 };


### PR DESCRIPTION
There is an error "Cannot read property '_hasX11' of undefined" if _channel property is undefined.
