### PR TITLE
Propagate socket timeouts to ChannelStream and SFTP.

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -565,12 +565,16 @@ function ChannelStream(channel) {
   this._outbuffer = [];
   this._inbuffer = [];
   this._decoder = undefined;
+  this._sockOnTimeout = function() {
+    self.emit('timeout');
+  }
   this._sockOnEnd = function() {
     !emittedFinish && self.emit('finish');
     !emittedEnd && self.emit('end');
     !emittedClose && self.emit('close');
     self.writable = false;
     self.readable = false;
+    channel._conn._sock.removeListener('timeout', self._sockOnTimeout);
     channel._conn._sock.removeListener('end', self._sockOnEnd);
     channel._conn._sock.removeListener('close', self._sockOnEnd);
   };
@@ -580,6 +584,7 @@ function ChannelStream(channel) {
   this.once('end', onEnd);
   function onClose() { emittedClose = true; }
   this.once('close', onClose);
+  channel._conn._sock.on('timeout', this._sockOnTimeout)
   channel._conn._sock.once('end', this._sockOnEnd);
   channel._conn._sock.once('close', this._sockOnEnd);
 }
@@ -766,6 +771,7 @@ ChannelStream.prototype._cleanup = function() {
   if (this._channel) {
     if (this._channel._hasX11)
       this._channel._hasX11 = false;
+    this._channel._conn._sock.removeListener('timeout', this._sockOnTimeout);
     this._channel._conn._sock.removeListener('end', this._sockOnEnd);
     this._channel._conn._sock.removeListener('close', this._sockOnEnd);
   }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -514,6 +514,9 @@ Connection.prototype.connect = function(opts) {
   this._sock.on('data', function(data) {
     self._parser.execute(data);
   });
+  this._sock.on('timeout', function() {
+    self.emit('timeout');
+  })
   this._sock.once('error', function(err) {
     clearTimeout(self._readyTimeout);
     err.level = 'connection-socket';
@@ -545,7 +548,7 @@ Connection.prototype.connect = function(opts) {
   if (!opts.sock) {
     this._sock.setNoDelay(true);
     this._sock.setMaxListeners(0);
-    this._sock.setTimeout(0);
+    this._sock.setTimeout(typeof opts.timeout === 'number' ? opts.timeout : 0);
     this._sock.connect(this._port, this._host);
   }
 };

--- a/lib/SFTP/SFTPv3.js
+++ b/lib/SFTP/SFTPv3.js
@@ -48,6 +48,9 @@ function SFTP(stream) {
     if (!type)
       self._parse(data);
   });
+  stream.once('timeout', function() {
+    self.emit('timeout');
+  });
   stream.once('error', function(err) {
     self.emit('error', err);
   });


### PR DESCRIPTION
This patch adds an option to specify the timeout for the socket underlying the SSH connection.  If a timeout occurs, it is propagated to any ChannelStreams and SFTP instances that are running over the connection.

I've encountered an environment in which these occur frequently, and this allows me to fail gracefully when data is no longer received or transmitted.
