### PR TITLE
return the underlying write() result from connection._send when encryption is enabled

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1347,12 +1347,12 @@ Connection.prototype._send = function(payload, cb, bypass) {
       if (final.length)
         self._sock.write(final, 'binary');
 
-      self._sock.write(encrypt.getAuthTag());
+      ret = self._sock.write(encrypt.getAuthTag());
 
       iv_inc(self._encryptIV);
     } else {
       self._sock.write(self._encrypt.update(buf, 'binary', 'binary'), 'binary');
-      self._sock.write(hmac);
+      ret = self._sock.write(hmac);
     }
   } else
     ret = self._sock.write(buf);


### PR DESCRIPTION
fixes #133
