### PR TITLE
Support for connection hopping with configuration

### DIFF
--- a/lib/TunneledConnection.js
+++ b/lib/TunneledConnection.js
@@ -1,0 +1,48 @@
+var Connection = require('./Connection')
+var util = require('util')
+
+function Tunnel(){
+    this.tunnel = null;
+    Connection.call(this);
+}
+
+util.inherits(Tunnel, Connection)
+
+Tunnel.prototype.connect = function(options){
+    var self = this;
+    if(options.tunnel){
+        var tunnelOptions = util._extend({}, options.tunnel); // clone
+        this.tunnel = new Tunnel();
+        this.tunnel.on('ready', function () {
+            self.emit('tunnel:ready', options.tunnel.host);
+            var ncCmd = 'nc ' + options.host + ' 22';
+            self.tunnel.exec(ncCmd, function (err, stream) {
+                if (err) return self.emit('error', err);
+                var innerOptions = util._extend({}, options)
+                innerOptions.sock = stream;
+                delete(innerOptions.host)
+                Tunnel.super_.prototype.connect.call(self,innerOptions);
+            });
+        });
+        self.tunnel.on('error', function (err) {
+            self.emit('tunnel:error', err, options.tunnel.host);
+        });
+
+        self.on('error', function(err) {
+            self.end();
+            self.tunnel.end();
+        });
+        self.on('end', function() {
+            self.tunnel.end();
+        });
+        self.on('close', function(had_error) {
+            self.tunnel.end();
+        });
+        self.tunnel.connect(tunnelOptions);
+    } else {
+        Tunnel.super_.prototype.connect.call(this,options)
+    };
+}
+
+module.exports = Tunnel;
+


### PR DESCRIPTION
Connection hopping with configuration. Options can take an additional parameter tunnel and goes hopping recursively.
Events 'tunnel:ready', 'tunnel:error' for listening on inner connections.

```
var Connection = require('ssh2/lib/TunneledConnection');

var c = new Connection();
c.on('ready', function() {
  console.log('Connection :: ready');
  c.exec('uptime', function(err, stream) {
    if (err) throw err;
    stream.on('data', function(data, extended) {
      console.log((extended === 'stderr' ? 'STDERR: ' : 'STDOUT: ')
                  + data);
    });
    stream.on('exit', function(code, signal) {
      c.end();
    });
  });
});

c.on('tunnel:error', function(err, host) {
  console.log(host + ' :: error :: ' + err);
});

c.on('tunnel:ready', function(host){
  console.log(host + ":: ready")
});

c.connect({
 host: '192.168.100.100',
  port: 22,
  username: 'frylock',
  privateKey: require('fs').readFileSync('/here/is/my/key')
  tunnel: {
     host: '192.168.100.101',
     port: 22,
    username: 'frylock2',
    privateKey: require('fs').readFileSync('/here/is/my/key')
    tunnel: {
       ..........
    }
  }
});
```
