### PR TITLE
Emit or throw error on exec() and connect()

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -199,12 +199,21 @@ inherits(Connection, EventEmitter);
 Connection.prototype.connect = function(opts) {
   var self = this;
 
+  /**
+   * Possible cases for this block will be executed are listed below
+   *
+   * 1. _state == "connecting"
+   *   this has been called connect() twiced before any internal event
+   * 2. _state == "initexchg"
+   *   this has been called connect() twiced after 'connect' event
+   * 3. _state == "authenticated"
+   *   this has been called connect() twiced after authenticated
+   *
+   * Throw errors will be better for handling those 3 cases instead of doing
+   * re-connection
+   */
   if (this._state !== 'closed') {
-    this.once('close', function() {
-      self.connect(opts);
-    });
-    this.end();
-    return;
+    throw new Error("Duplicated connect() calls detected.");
   }
 
   this._host = opts.host || 'localhost';

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -971,7 +971,12 @@ Connection.prototype._openChan = function(type, blob, cb) {
     blob.copy(buf, p += 4);
 
   this._debug && this._debug('DEBUG: Connection: Sending CHANNEL_OPEN');
-  return this._send(buf);
+  var ret = this._send(buf);                                                                                                                   
+  if (typeof ret === 'undefined') {
+    var err = new Error('Socket end prematurely');
+    cb(err);
+  }
+  return ret; 
 };
 
 Connection.prototype._nextChan = function() {

--- a/test/test-duplicated-connection.js
+++ b/test/test-duplicated-connection.js
@@ -1,0 +1,125 @@
+/**
+ * Test throwing errors if clients call connect on an established socket
+ * (Refer to issue #161)
+ *
+ * @author: Mond Wan
+ * @email: mondwan.1015@gmail.com
+ * @last-modified: 2014-07-20 15:04
+ */
+
+var Q = require('q');
+var Connection = require('../lib/Connection');
+var util = require('util');
+
+var c = new Connection();
+var status = "READY";
+var validation = false;
+
+var connect = function () {
+    var deferred = Q.defer();
+
+    c.once("ready", function () {
+        //console.log('Connection::Ready');
+        c.removeAllListeners("error");
+        status = "READY";
+        deferred.resolve(c);
+    });
+    c.once("error", function (err) {
+        c.removeAllListeners("ready");
+        status = "ERROR";
+        deferred.reject(err);
+    });
+    //c.once('keyboard-interactive', function (
+
+    c.connect({
+        host: 'localhost',
+        port: 22,
+        username: 'mond',
+        //debug: console.log,
+        password: "mondwan"
+    });
+
+    return deferred.promise;
+};
+
+var send = function (cmd) {
+    var deferred = Q.defer();
+
+    if (status !== "READY") {
+        deferred.reject(new Error("Oops. Socket is closed"));
+    } else {
+        c.exec(cmd, function (err, stream) {
+            if (err) {
+                deferred.reject(err);
+                return;
+            }
+            stream.setEncoding("utf8");
+
+            var results = [];
+            stream.on("data", function (data) {
+                //console.log("connection::data");
+                results.push(data);
+            });
+            stream.on("exit", function (code, signal) {
+                deferred.resolve({
+                    code: code,
+                    signal: signal,
+                    results: results
+                });
+            });
+        });
+    }
+
+    return deferred.promise;
+};
+
+var disconnect = function () {
+    var deferred = Q.defer();
+
+    c.once("close", function (err) {
+        //console.log("Connection::close");
+        //status = "CLOSED";
+        if (err) {
+            deferred.reject(err);
+        } else {
+            deferred.resolve(true);
+        }
+    });
+    c.end();
+    return deferred.promise;
+};
+
+// o1
+//console.log('o1 call conenct()');
+connect().then(function () {
+    //console.log('o1 connect()');
+    return send('sleep 2s;echo "o1.send()"');
+})
+.then(function (res) {
+    //console.log(util.format("o1.send().respone()"), res);
+})
+.finally(disconnect)
+.done();
+
+try {
+    // o2
+    //console.log('o2 call conenct()');
+    connect().then(function () {
+        //console.log('o2 connect()');
+        return Q.delay(3000);
+    })
+    .then(function () {
+        return send('echo "o2.send()"');
+    })
+    .then(function (res) {
+        //console.log(util.format("o2.send().respone()"), res);
+    })
+    .finally(disconnect)
+    .done();
+} catch (err) {
+    validation = true;
+}
+
+if (!validation) {
+    throw new Error("Should throw errors for duplicated connect()");
+}

--- a/test/test-exec-on-closed-socket.js
+++ b/test/test-exec-on-closed-socket.js
@@ -1,0 +1,108 @@
+/**
+ * Test throwing errors if clients call connect on an established socket
+ * (Refer to issue #161)
+ *
+ * @author: Mond Wan
+ * @email: mondwan.1015@gmail.com
+ * @last-modified: 2014-07-20 15:04
+ */
+
+var Q = require('q');
+var Connection = require('../lib/Connection');
+var util = require('util');
+
+var c = new Connection();
+var status = "READY";
+var validation = false;
+
+var connect = function () {
+    var deferred = Q.defer();
+
+    c.once("ready", function () {
+        //console.log('Connection::Ready');
+        c.removeAllListeners("error");
+        status = "READY";
+        deferred.resolve(c);
+    });
+    c.once("error", function (err) {
+        c.removeAllListeners("ready");
+        status = "ERROR";
+        deferred.reject(err);
+    });
+    //c.once('keyboard-interactive', function (
+
+    c.connect({
+        host: 'localhost',
+        port: 22,
+        username: 'mond',
+        //debug: console.log,
+        password: "mondwan"
+    });
+
+    return deferred.promise;
+};
+
+var send = function (cmd) {
+    var deferred = Q.defer();
+
+    if (status !== "READY") {
+        deferred.reject(new Error("Oops. Socket is closed"));
+    } else {
+        c.exec(cmd, function (err, stream) {
+            if (err) {
+                deferred.reject(err);
+                return;
+            }
+            stream.setEncoding("utf8");
+
+            var results = [];
+            stream.on("data", function (data) {
+                //console.log("connection::data");
+                results.push(data);
+            });
+            stream.on("exit", function (code, signal) {
+                deferred.resolve({
+                    code: code,
+                    signal: signal,
+                    results: results
+                });
+            });
+        });
+    }
+
+    return deferred.promise;
+};
+
+var disconnect = function () {
+    var deferred = Q.defer();
+
+    c.once("close", function (err) {
+        //console.log("Connection::close");
+        //status = "CLOSED";
+        if (err) {
+            deferred.reject(err);
+        } else {
+            deferred.resolve(true);
+        }
+    });
+    c.end();
+    return deferred.promise;
+};
+
+connect().then(function () {
+    return send('echo "Command 1"');
+}).then(function (res) {
+    //console.log(util.format("send().respone()"), res);
+}).then(function () {
+    return disconnect();
+}).then(function () {
+    return send('echo "Command 2"');
+}).catch(function (err) {
+    if (err.message === 'Socket end prematurely') {
+        validation = true;
+    }
+}).finally(function () {
+    if (!validation) {
+        throw new Error("Should throw error on calling exec() on a closed socket");
+    }
+}).done();


### PR DESCRIPTION
--Overview
* Implementation for issue #161
* Treat twice connect() as a programmer error, throw error immediately....
* Treat exec() on a closed socket as operational error, emit error instead of throwing error
* Provide 2 test cases for testing above implementation. However, you need to modify a bit on connect() calls.