### PR TITLE
add setWindows support for exec session

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,9 +884,6 @@ This is a normal **streams2** Duplex Stream, with the following changes:
 
 * Client-only:
 
-    * For shell():
-
-        * **setWindow**(< _integer_ >rows, < _integer_ >cols, < _integer_ >height, < _integer_ >width) - _boolean_ - Lets the server know that the local terminal window has been resized. The meaning of these arguments are described in the 'Pseudo-TTY settings' section. Returns `false` if you should wait for the `continue` event before sending any more traffic.
 
     * For exec():
 
@@ -901,6 +898,8 @@ This is a normal **streams2** Duplex Stream, with the following changes:
         * A `stderr` property contains a Readable stream that represents output from stderr.
 
         * **signal**(< _string_ >signalName) - _boolean_ - Sends a POSIX signal to the current process on the server. Valid signal names are: 'ABRT', 'ALRM', 'FPE', 'HUP', 'ILL', 'INT', 'KILL', 'PIPE', 'QUIT', 'SEGV', 'TERM', 'USR1', and 'USR2'. Some server implementations may ignore this request if they do not support signals. Note: If you are trying to send SIGINT and you find `signal()` doesn't work, try writing `'\x03'` to the Channel stream instead. Returns `false` if you should wait for the `continue` event before sending any more traffic.
+
+        * **setWindow**(< _integer_ >rows, < _integer_ >cols, < _integer_ >height, < _integer_ >width) - _boolean_ - Lets the server know that the local terminal window has been resized. The meaning of these arguments are described in the 'Pseudo-TTY settings' section. Returns `false` if you should wait for the `continue` event before sending any more traffic.
 
 * Server-only:
 

--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -355,7 +355,7 @@ Channel.prototype.setWindow = function(rows, cols, height, width) {
     throw new Error('Client-only method called in server mode');
 
   if (this.type === 'session'
-      && this.subtype === 'shell'
+      && (this.subtype === 'shell' || this.subtype === 'exec')
       && this.writable
       && this.outgoing.state === 'open') {
     return this._client._sshstream.windowChange(this.outgoing.id,


### PR DESCRIPTION
exec session also can be interactive. For example you can run command ssh -t youname@hostname /bin/bash , this will be a interactive exec request.