### PR TITLE
Client: don't check passphrase if an agent is provided

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -141,7 +141,7 @@ Client.prototype.connect = function(cfg) {
   this._curChan = -1;
   this._remoteVer = undefined;
 
-  if (this.config.privateKey) {
+  if (this.config.privateKey && !this.config.agent) {
     var privKeyInfo = parseKey(this.config.privateKey);
     if (privKeyInfo instanceof Error)
       throw new Error('Cannot parse privateKey: ' + privKeyInfo.message);


### PR DESCRIPTION
The privateKey passphare shouldn't be checked if there was an agent provided in the config object. Otherwise the error "Encrypted private key detected, but no passphrase given" is thrown altough the privateKey could be encrypted by using the agent.