### PR TITLE
Bugfix: Server() called without new

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -21,7 +21,7 @@ var kaMgr;
 
 function Server(cfg, listener) {
   if (!(this instanceof Server))
-    return new Server(cfg);
+    return new Server(cfg, listener);
 
   if (!kaMgr
       && Server.KEEPALIVE_INTERVAL > 0


### PR DESCRIPTION
If the Server() function was called without 'new', the returned
object ignored the listener.