### PR TITLE
Server: guarantee global-request reply order

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -264,7 +264,34 @@ function Client(stream, socket) {
   }
   // end service/auth-related ==================================================
 
+  var unrepliedGlobalRequests = [];
+
+  function sendReplies() {
+    var reply;
+    while (unrepliedGlobalRequests[0] && unrepliedGlobalRequests[0].type) {
+      reply = unrepliedGlobalRequests.shift();
+      if (reply.type === 'SUCCESS') {
+        stream.requestSuccess(reply.buf);
+      }
+      if (reply.type === 'FAILURE') {
+        stream.requestFailure();
+      }
+    }
+  }
+
   stream.on('GLOBAL_REQUEST', function(name, wantReply, data) {
+    var reply = {};
+
+    function setReply(type, buf) {
+      reply.type = type;
+      reply.buf = buf;
+      sendReplies();
+    }
+
+    if (wantReply) {
+      unrepliedGlobalRequests.push(reply);
+    }
+
     if ((name === 'tcpip-forward'
          || name === 'cancel-tcpip-forward'
          || name === 'no-more-sessions@openssh.com'
@@ -288,13 +315,13 @@ function Client(stream, socket) {
             bufPort = new Buffer(4);
             bufPort.writeUInt32BE(chosenPort, 0, true);
           }
-          return stream.requestSuccess(bufPort);
+          setReply('SUCCESS', bufPort);
         };
         reject = function() {
           if (replied)
             return;
           replied = true;
-          return stream.requestFailure();
+          setReply('FAILURE');
         };
       }
 
@@ -306,7 +333,7 @@ function Client(stream, socket) {
 
       self.emit('request', accept, reject, name, data);
     } else if (wantReply)
-      stream.requestFailure();
+      setReply('FAILURE');
   });
 
   stream.on('CHANNEL_OPEN', function(info) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -264,23 +264,25 @@ function Client(stream, socket) {
   }
   // end service/auth-related ==================================================
 
-  var unrepliedGlobalRequests = [];
+  var unsentGlobalRequestsReplies = [];
 
   function sendReplies() {
     var reply;
-    while (unrepliedGlobalRequests[0] && unrepliedGlobalRequests[0].type) {
-      reply = unrepliedGlobalRequests.shift();
-      if (reply.type === 'SUCCESS') {
+    while (unsentGlobalRequestsReplies.length > 0
+           && unsentGlobalRequestsReplies[0].type) {
+      reply = unsentGlobalRequestsReplies.shift();
+      if (reply.type === 'SUCCESS')
         stream.requestSuccess(reply.buf);
-      }
-      if (reply.type === 'FAILURE') {
+      if (reply.type === 'FAILURE')
         stream.requestFailure();
-      }
     }
   }
 
   stream.on('GLOBAL_REQUEST', function(name, wantReply, data) {
-    var reply = {};
+    var reply = {
+      type: null,
+      buf:null
+    };
 
     function setReply(type, buf) {
       reply.type = type;
@@ -289,7 +291,7 @@ function Client(stream, socket) {
     }
 
     if (wantReply) {
-      unrepliedGlobalRequests.push(reply);
+      unsentGlobalRequestsReplies.push(reply);
     }
 
     if ((name === 'tcpip-forward'

--- a/test/test-client-server.js
+++ b/test/test-client-server.js
@@ -1203,8 +1203,10 @@ var tests = [
           fastrejectSent = false;
 
       function sendAcceptLater(accept) {
-        if (fastrejectSent) accept();
-        else setImmediate(sendAcceptLater, accept);
+        if (fastrejectSent)
+          accept();
+        else
+          setImmediate(sendAcceptLater, accept);
       }
 
       r = setup(this, { username: USER }, { privateKey: HOST_KEY_RSA });
@@ -1221,10 +1223,9 @@ var tests = [
             // Will call reject on 'fastreject' soon
             reject();
             fastrejectSent = true;
-          } else {
+          } else
             // but accept on 'slowaccept' later
             sendAcceptLater(accept);
-          }
         });
       });
 
@@ -1233,12 +1234,14 @@ var tests = [
 
         client.forwardIn('slowaccept', 0, function(err) {
           assert(!err, makeMsg(what, 'Unexpected error: ' + err));
-          if (++replyCnt === 2) client.end();
+          if (++replyCnt === 2)
+            client.end();
         });
 
         client.forwardIn('fastreject', 0, function(err) {
           assert(err, makeMsg(what, 'Should receive error'));
-          if (++replyCnt === 2) client.end();
+          if (++replyCnt === 2)
+            client.end();
         });
       });
     },

--- a/test/test-client-server.js
+++ b/test/test-client-server.js
@@ -1199,25 +1199,24 @@ var tests = [
           what = this.what,
           client,
           server,
-          r;
+          r,
+          fastrejectSent = false;
+
+      function sendAcceptLater(accept) {
+        if (fastrejectSent) accept();
+        else setImmediate(sendAcceptLater, accept);
+      }
 
       r = setup(this, { username: USER }, { privateKey: HOST_KEY_RSA });
       client = r.client;
       server = r.server;
 
       server.on('connection', function(conn) {
-        var fastrejectSent = false;
-
         conn.on('authentication', function(ctx) {
           ctx.accept();
         });
 
         conn.on('request', function(accept, reject, name, info) {
-          function sendAcceptLater() {
-            if (fastrejectSent) accept();
-            else process.nextTick(sendAcceptLater);
-          }
-
           if (info.bindAddr === 'fastreject') {
             // Will call reject on 'fastreject' soon
             reject();


### PR DESCRIPTION
When the client sends a global request to the server, we usually provide
server implementors with 'accept' and 'reject' callback functions to
decide on the request. This 'decision process' can take some time, so
the order of calling 'accept' or 'reject' may be out-of-order.

This commit guarantees that the server sends these responses back to the
client in order they were received.

It could be a good idea to auto-reject long-waiting requests or at least notify implementors. What do you think?