### PR TITLE
Inconsistent cfg.username vs cfg.user when empty

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -173,7 +173,7 @@ Client.prototype.connect = function(cfg) {
       algorithms.compress = ['none'];
   }
 
-  this.config.username = cfg.username || cfg.user;
+  this.config.username = cfg.username || cfg.user || undefined;
   this.config.password = (typeof cfg.password === 'string'
                           ? cfg.password
                           : undefined);


### PR DESCRIPTION
I noticed an inconsistency between specifying cfg.username and cfg.user when it is an empty string.

This throws an "Invalid username" Error:
```
conn.connect({username: "", host: "myHost", port: "myPort", password: "myPassword"});
```
This doesn't throw and continues with username as an empty string:
```
conn.connect({user: "", host: "myHost", port: "myPort", password: "myPassword"});
```
The behavior should be consistent between the two: either, both should cause conn.connect to throw, or neither should. This commit assumes that it should throw in both cases.