### PR TITLE
Add ping method to Channel

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -379,6 +379,15 @@ Channel.prototype.destroy = function() {
   this.end();
 };
 
+Channel.prototype.ping = function() {
+  if (this.type === 'session'
+      && this.writable
+      && this.outgoing.state === 'open')
+    return this._client._sshstream.ping();
+
+  return true;
+};
+
 // session type-specific methods
 Channel.prototype.setWindow = function(rows, cols, height, width) {
   if (this.server)


### PR DESCRIPTION
Exposing the underlying streams ping method is useful for measuring session latency among other things.