### PR TITLE
Agent,Client: remove `noAssert` argument

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -53,13 +53,13 @@ module.exports = function(sockPath, key, keyType, data, cb) {
       */
       var p = 9;
       buf = new Buffer(4 + 1 + 4 + keylen + 4 + datalen + 4);
-      buf.writeUInt32BE(buf.length - 4, 0, true);
+      buf.writeUInt32BE(buf.length - 4, 0);
       buf[4] = SIGN_REQUEST;
-      buf.writeUInt32BE(keylen, 5, true);
+      buf.writeUInt32BE(keylen, 5);
       key.copy(buf, p);
-      buf.writeUInt32BE(datalen, p += keylen, true);
+      buf.writeUInt32BE(datalen, p += keylen);
       data.copy(buf, p += 4);
-      buf.writeUInt32BE(0, p += datalen, true);
+      buf.writeUInt32BE(0, p += datalen);
       sock.write(buf);
     } else {
       /*
@@ -234,7 +234,7 @@ module.exports = function(sockPath, key, keyType, data, cb) {
 
           // convert to host order (always LE for Windows)
           for (i = 0; i < 16; i += 4)
-            secretbuf.writeUInt32LE(secretbuf.readUInt32BE(i, true), i, true);
+            secretbuf.writeUInt32LE(secretbuf.readUInt32BE(i), i);
 
           function _onconnect() {
             bc = 0;
@@ -267,7 +267,7 @@ module.exports = function(sockPath, key, keyType, data, cb) {
                 } else {
                   isRetrying = true;
                   credsbuf = Buffer.concat(inbuf);
-                  credsbuf.writeUInt32LE(process.pid, 0, true);
+                  credsbuf.writeUInt32LE(process.pid, 0);
                   sock.destroy();
                   tryConnect();
                 }
@@ -365,7 +365,7 @@ if (process.platform === 'win32') {
     if (this.buffer.length < 4)
       return;
 
-    var len = this.buffer.readUInt32BE(0, true);
+    var len = this.buffer.readUInt32BE(0);
     // Make sure we have a full message before querying pageant
     if ((this.buffer.length - 4) < len)
       return;

--- a/lib/client.js
+++ b/lib/client.js
@@ -498,7 +498,7 @@ Client.prototype.connect = function(cfg) {
   function onUSERAUTH_PK_OK() {
     if (curAuth === 'agent') {
       var agentKey = agentKeys[agentKeyPos];
-      var keyLen = agentKey.readUInt32BE(0, true);
+      var keyLen = agentKey.readUInt32BE(0);
       var pubKeyFullType = agentKey.toString('ascii', 4, 4 + keyLen);
       var pubKeyType = pubKeyFullType.slice(4);
       // Check that we support the key type first
@@ -526,7 +526,7 @@ Client.prototype.connect = function(cfg) {
             err.level = 'agent';
             self.emit('error', err);
           } else {
-            var sigFullTypeLen = signed.readUInt32BE(0, true);
+            var sigFullTypeLen = signed.readUInt32BE(0);
             if (4 + sigFullTypeLen + 4 < signed.length) {
               var sigFullType = signed.toString('ascii', 4, 4 + sigFullTypeLen);
               if (sigFullType !== pubKeyFullType) {
@@ -936,7 +936,7 @@ Client.prototype.forwardIn = function(bindAddr, bindPort, cb) {
 
       var realPort = bindPort;
       if (bindPort === 0 && data && data.length >= 4) {
-        realPort = data.readUInt32BE(0, true);
+        realPort = data.readUInt32BE(0);
         if (!(self._sshstream.remoteBugs & BUGS.DYN_RPORT_BUG))
           bindPort = realPort;
       }


### PR DESCRIPTION
The support for `noAssert` dropped in Node.js v.10.x and it has no
effect anymore. This removes the argument therefore.

Refs: https://github.com/nodejs/node/pull/18395