### PR TITLE
add x11opts to reqX11

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,10 @@ You can find more examples in the `examples` directory of this repository.
 
         * **screen** - _number_ - Screen number to use **Default:** `0`
 
+        * **protocol** - _string_ - The name of the X11 authentication method used **Default:** `MIT-MAGIC-COOKIE-1`
+
+        * **cookie** - _string_ - The X11 authentication cookie encoded in hexadecimal. **Default:** random 16 byte hex string in ASCII `crypto.randomBytes(16).toString('hex')`
+
 * **shell**([[< _mixed_ >window,] < _object_ >options]< _function_ >callback) - _boolean_ - Starts an interactive shell session on the server, with an optional `window` object containing pseudo-tty settings (see 'Pseudo-TTY settings'). If `window === false`, then no pseudo-tty is allocated. `options` supports the `x11` and `env` options as described in `exec()`. `callback` has 2 parameters: < _Error_ >err, < _Channel_ >stream. Returns `false` if you should wait for the `continue` event before sending any more traffic.
 
 * **forwardIn**(< _string_ >remoteAddr, < _integer_ >remotePort, < _function_ >callback) - _boolean_ - Bind to `remoteAddr` on `remotePort` on the server and forward incoming TCP connections. `callback` has 2 parameters: < _Error_ >err, < _integer_ >port (`port` is the assigned port number if `remotePort` was 0). Returns `false` if you should wait for the `continue` event before sending any more traffic. Here are some special values for `remoteAddr` and their associated binding behaviors:

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ You can find more examples in the `examples` directory of this repository.
 
         * **protocol** - _string_ - The name of the X11 authentication method used **Default:** `MIT-MAGIC-COOKIE-1`
 
-        * **cookie** - _string_ - The X11 authentication cookie encoded in hexadecimal. **Default:** random 16 byte hex string in ASCII `crypto.randomBytes(16).toString('hex')`
+        * **cookie** - _string_ - The X11 authentication cookie encoded in hexadecimal. **Default:** random 16 byte hex string in ASCII
 
 * **shell**([[< _mixed_ >window,] < _object_ >options]< _function_ >callback) - _boolean_ - Starts an interactive shell session on the server, with an optional `window` object containing pseudo-tty settings (see 'Pseudo-TTY settings'). If `window === false`, then no pseudo-tty is allocated. `options` supports the `x11` and `env` options as described in `exec()`. `callback` has 2 parameters: < _Error_ >err, < _Channel_ >stream. Returns `false` if you should wait for the `continue` event before sending any more traffic.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1227,24 +1227,29 @@ function nextChannel(self) {
   return false;
 }
 
-function reqX11(chan, screen, cb) {
+function reqX11(chan, opts, cb) {
   // asks server to start sending us X11 connections
-  var cfg = {
+  // replace "screen" option with "opts" object to allow full parameters to be
+  // passed to reqX11 function. Also backwards compatible to previous "screen"/"single"
+  // only variable/object.
+   var cfg = {
     single: false,
     protocol: 'MIT-MAGIC-COOKIE-1',
     cookie: crypto.randomBytes(16).toString('hex'),
     screen: (typeof screen === 'number' ? screen : 0)
   };
-
-  if (typeof screen === 'function')
-    cb = screen;
-  else if (typeof screen === 'object') {
-    if (typeof screen.single === 'boolean')
-      cfg.single = screen.single;
-    if (typeof screen.screen === 'number')
-      cfg.screen = screen.screen;
+  if (typeof opts === 'function')
+    cb = opts;  
+  else if (typeof opts === 'object') {
+    if (typeof opts.single === 'boolean')
+      cfg.single = opts.single;
+    if (typeof opts.screen === 'number')
+      cfg.screen = opts.screen;
+    if (typeof opts.protocol === 'string')
+      cfg.protocol = opts.protocol
+    if (typeof opts.cookie === 'string')
+      cfg.cookie = opts.cookie
   }
-
   var wantReply = (typeof cb === 'function');
 
   if (chan.outgoing.state !== 'open') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1236,7 +1236,7 @@ function reqX11(chan, opts, cb) {
     single: false,
     protocol: 'MIT-MAGIC-COOKIE-1',
     cookie: crypto.randomBytes(16).toString('hex'),
-    screen: (typeof screen === 'number' ? screen : 0)
+    screen: (typeof opts === 'number' ? opts : 0)
   };
   if (typeof opts === 'function')
     cb = opts;  

--- a/test/test-client-server.js
+++ b/test/test-client-server.js
@@ -794,6 +794,8 @@ var tests = [
                 makeMsg('Wrong protocol: ' + info.protocol))
               assert(info.screen === 0,
                 makeMsg('Wrong screen: ' + info.screen))
+              assert(info.cookie.length === 64, 
+                makeMsg('Wrong cookie'))
               accept && accept();
             }).once('exec', function(accept, reject, info) {
               assert(info.command === 'foo --bar',


### PR DESCRIPTION
# add additional opts to reqX11
- maintain backwards compatibility for previous single/screen methods, expand to allow specifying protocol and cookie methods to support proxying.