### PR TITLE
adding in server response of accepted methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ new ssh2.Server({
         ctx.accept();
       }
     } else
-      ctx.reject();
+      ctx.reject(['publickey','password']);
   }).on('ready', function() {
     console.log('Client authenticated!');
 
@@ -527,7 +527,7 @@ new ssh2.Server({
         && ctx.password === 'bar')
       ctx.accept();
     else
-      ctx.reject();
+      ctx.reject(['password']);
   }).on('ready', function() {
     console.log('Client authenticated!');
 


### PR DESCRIPTION
If the client sends the 'none' type authentication, in some cases it expects to receive a list of approved authentication methods. The puTTY client does this, for instance. To allow users to connect to the example SSH server using puTTY, it needs to return an appropriate set of authorizations.