### PR TITLE
Treat named pipes in Windows as UNIX sockets

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -18,7 +18,7 @@ var FAILURE = 5;
 var RE_CYGWIN_SOCK = /^\!<socket >(\d+) s ([A-Z0-9]{8}\-[A-Z0-9]{8}\-[A-Z0-9]{8}\-[A-Z0-9]{8})/;
 
 // Format of `//./pipe/ANYTHING`, with forward slashes and backward slashes being interchangeable
-var WINDOWS_PIPE_REGEX = /^[/\\][/\\].[/\\]pipe[/\\].+/
+var WINDOWS_PIPE_REGEX = /^[/\\][/\\]\.[/\\]pipe[/\\].+/
 
 module.exports = function(sockPath, key, keyType, data, cb) {
   var sock;
@@ -190,7 +190,7 @@ module.exports = function(sockPath, key, keyType, data, cb) {
       cb(undefined, keys);
   }
 
-  if (process.platform === 'win32' && !sockPath.match(WINDOWS_PIPE_REGEX)) {
+  if (process.platform === 'win32' && !WINDOWS_PIPE_REGEX.test(sockPath)) {
     if (sockPath === 'pageant') {
       // Pageant (PuTTY authentication agent)
       sock = new PageantSock();

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -17,6 +17,9 @@ var FAILURE = 5;
 
 var RE_CYGWIN_SOCK = /^\!<socket >(\d+) s ([A-Z0-9]{8}\-[A-Z0-9]{8}\-[A-Z0-9]{8}\-[A-Z0-9]{8})/;
 
+// Format of `//./pipe/ANYTHING`, with forward slashes and backward slashes being interchangeable
+var WINDOWS_PIPE_REGEX = /^[/\\][/\\].[/\\]pipe[/\\].+/
+
 module.exports = function(sockPath, key, keyType, data, cb) {
   var sock;
   var error;
@@ -187,7 +190,7 @@ module.exports = function(sockPath, key, keyType, data, cb) {
       cb(undefined, keys);
   }
 
-  if (process.platform === 'win32') {
+  if (process.platform === 'win32' && !sockPath.match(WINDOWS_PIPE_REGEX)) {
     if (sockPath === 'pageant') {
       // Pageant (PuTTY authentication agent)
       sock = new PageantSock();


### PR DESCRIPTION
On Windows systems, it is assumed that any sockPath is either Pageant, or a cygwin path. This commit makes named pipes be treated as UNIX sockets.

This is to support ssh-agent for OpenSSH that can be installed on Windows 10. This uses the named pipe `//./pipe/openssh-ssh-agent`.

This allows me to use the Windows 10 version of `ssh-add` and use the key by setting the `agent` option to `//./pipe/openssh-ssh-agent` when creating a SSH connection.