### PR TITLE
Add missing break statement causing all auth to be rejected

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ new ssh2.Server({
             || !crypto.timingSafeEqual(password, allowedPassword)) {
           return ctx.reject();
         }
+        break;
       default:
         return ctx.reject();
     }


### PR DESCRIPTION
**SFTP-only server** example is missing break statement in auth