### PR TITLE
Use authMethodsLeft in the sample servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ new ssh2.Server({
         }
         break;
       default:
-        return ctx.reject();
+        return ctx.reject(['password', 'publickey']);
     }
 
     ctx.accept();
@@ -537,7 +537,7 @@ new ssh2.Server({
           return ctx.reject();
         }
       default:
-        return ctx.reject();
+        return ctx.reject(['password']);
     }
 
     ctx.accept();


### PR DESCRIPTION
RFC 4252, which covers ssh authentication, allows clients to respond
to request the auth method 'none', to which the server should respond
with a list of allowed methods. In particular, WinSCP performs this
check, and if the server responds with an empty list, it terminates
the session. (Most other clients just try various methods without
checking.)

So, it'll be good to handle this case in the sample server
implementations as a hint to implementors about this part of the
protocol.