### PR TITLE
docs: Update README example to go next on failed authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ new ssh2.Server({
         var password = Buffer.from(ctx.password);
         if (password.length !== allowedPassword.length
             || !crypto.timingSafeEqual(password, allowedPassword)) {
-          return ctx.reject();
+          return ctx.reject(['password', 'publickey']);
         }
         break;
       case 'publickey':
@@ -474,11 +474,11 @@ new ssh2.Server({
             || ctx.key.data.length !== allowedPubSSHKey.length
             || !crypto.timingSafeEqual(ctx.key.data, allowedPubSSHKey)
             || (ctx.signature && !allowedPubKey.verify(ctx.blob, ctx.signature))) {
-          return ctx.reject();
+          return ctx.reject(['password', 'publickey']);
         }
         break;
       default:
-        return ctx.reject();
+        return ctx.reject(['password', 'publickey']);
     }
 
     ctx.accept();


### PR DESCRIPTION
Hello,

Due to the coomon expectations of users (resulting from the coomon OpenSSH configuration), I propose to adjust the published example in order to ask for another form of authentication in case of incorrect access data.

This is especially important when using the ssh agent, as the current example will fail if someone has more than two keys added to agent. After attempting to use the first one, the second one will not be used and the connection will be terminated due no more authentication methods available.

Greetings,