### PR TITLE
fix: Improper use of parseKey from ssh2-streams, fixes #766

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,11 +47,16 @@ function Server(cfg, listener) {
       privateKey = parseKey(hostKeys_[i].key, hostKeys_[i].passphrase);
     if (privateKey instanceof Error)
       throw new Error('Cannot parse privateKey: ' + privateKey.message);
-    if (privateKey.getPrivatePEM() === null)
-      throw new Error('privateKey value contains an invalid private key');
-    if (hostKeys[privateKey.type])
-      continue;
-    hostKeys[privateKey.type] = privateKey;
+    if( !Array.isArray(privateKey) ){
+      privateKey = [privateKey]
+    }
+
+    privateKey.forEach( function (key) {
+      if (key.getPrivatePEM() === null)
+        throw new Error('privateKey value contains an invalid private key');
+      if (!hostKeys[key.type])
+        hostKeys[key.type] = key;
+    })
   }
 
   var algorithms = {


### PR DESCRIPTION
According to ssh2-streams documentation: 
![image](https://user-images.githubusercontent.com/1921727/58759736-31fafc00-852f-11e9-9dfa-30ffaf5a71f1.png)
