### PR TITLE
Respect Terminal Modes specified in the `pty` configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,8 @@ This is a normal **streams2** Duplex Stream (used both by clients and servers), 
 
 * **term** - < _string_ > - The value to use for $TERM. **Default:** `'vt100'`
 
+* **modes** - < _object_ > - An object containing [Terminal Modes](#terminal-modes) as keys, with each value set to each mode argument. **Default:** `null`
+
 `rows` and `cols` override `width` and `height` when `rows` and `cols` are non-zero.
 
 Pixel dimensions refer to the drawable area of the window.

--- a/lib/client.js
+++ b/lib/client.js
@@ -1289,6 +1289,7 @@ function reqPty(chan, opts, cb) {
   var width = 640;
   var height = 480;
   var term = 'vt100';
+  var modes = null;
 
   if (typeof opts === 'function')
     cb = opts;
@@ -1303,6 +1304,8 @@ function reqPty(chan, opts, cb) {
       height = opts.height;
     if (typeof opts.term === 'string')
       term = opts.term;
+    if (typeof opts.modes === 'object')
+      modes = opts.modes;
   }
 
   var wantReply = (typeof cb === 'function');
@@ -1329,7 +1332,7 @@ function reqPty(chan, opts, cb) {
                                      height,
                                      width,
                                      term,
-                                     null,
+                                     modes,
                                      wantReply);
 }
 


### PR DESCRIPTION
When requesting a Pseudo-TTY, it can be useful to specify Terminal Modes to configure the pty. 

This PR checks for a `modes` key in the `pty` configuration object when requesting a Pseudo-TTY, and passes it through to the `SSH2Streams` `pty` call if present. 

Example usage:

```
const Client = require('ssh2').Client;
const zlib = require('zlib');

const conn = new Client();

conn.on('ready', function() {
    const options = {
        pty: {
            term: 'xterm',
            modes: { OPOST: 1 },
        }
    };

    conn.exec('uptime | gzip -f', options, function(err, stream) {
        if (err) throw err;

        stream.on('close', function(code, signal) {
            conn.end();
        });

        stream.pipe( zlib.createGunzip() ).pipe( process.stdout );
    });
});

conn.connect({ ... });
```

In this example, the output of `gzip` gets mangled by the pseudoterminal unless `{ OPOST: 0 }` gets passed through to deactivate output post-processing.