### PR TITLE
Handle sftp subsystem request as regular subsystem request

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -849,34 +849,38 @@ function Session(client, info, localChan) {
           reject && reject();
       break;
       case 'subsystem':
-        accept = function() {
-          if (replied || ending || channel)
-            return;
+        var createAccept = function(enableSFTPStream) {
+          return function accept() {
+            if (replied || ending || channel)
+              return;
 
-          replied = true;
+            replied = true;
 
-          if (info.wantReply)
-            client._sshstream.channelSuccess(outgoingId);
+            if (info.wantReply)
+              client._sshstream.channelSuccess(outgoingId);
 
-          channel = new Channel(chaninfo, client, { server: true });
+            channel = new Channel(chaninfo, client, { server: true });
 
-          channel.subtype = self.subtype = (info.request + ':' + info.subsystem);
+            channel.subtype = self.subtype = (info.request + ':' + info.subsystem);
 
-          if (info.subsystem === 'sftp') {
-            var sftp = new SFTPStream({
-              server: true,
-              debug: client._sshstream.debug
-            });
-            channel.pipe(sftp).pipe(channel);
+            if (enableSFTPStream) {
+              var sftp = new SFTPStream({
+                server: true,
+                debug: client._sshstream.debug
+              });
+              channel.pipe(sftp).pipe(channel);
 
-            return sftp;
-          } else
-            return channel;
+              return sftp;
+            } else
+              return channel;
+          };
         };
 
-        if (info.subsystem === 'sftp' && listenerCount(self, 'sftp'))
+        if (info.subsystem === 'sftp' && listenerCount(self, 'sftp')) {
+          accept = createAccept(true);
           self.emit('sftp', accept, reject);
-        else if (info.subsystem !== 'sftp' && listenerCount(self, 'subsystem')) {
+        } else if (listenerCount(self, 'subsystem')) {
+          accept = createAccept(false);
           self.emit('subsystem', accept, reject, {
             name: info.subsystem
           });


### PR DESCRIPTION
Closes #853

Emits the `subsystem` event for the `sftp` subsystem if there is no `sftp` listener.
