### PR TITLE
Detects if running in an electron asar file.

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -345,9 +345,9 @@ if (process.platform === 'win32') {
   var RET_ERR_BINSTDIN = 13;
   var RET_ERR_BINSTDOUT = 14;
   var RET_ERR_BADLEN = 15;
-
+  var RAWPATH = path.resolve(__dirname, '..', 'util/pagent.exe');
   var ERROR = {};
-  var EXEPATH = path.resolve(__dirname, '..', 'util/pagent.exe');
+  var EXEPATH = RAWPATH.includes('app.asar') ? RAWPATH.replace('app.asar', 'app.asar.unpacked') : RAWPATH;
   ERROR[RET_ERR_BADARGS] = new Error('Invalid pagent.exe arguments');
   ERROR[RET_ERR_UNAVAILABLE] = new Error('Pageant is not running');
   ERROR[RET_ERR_NOMAP] = new Error('pagent.exe could not create an mmap');


### PR DESCRIPTION
When running in an Electron `asar` file, `spawn` is unable to resolve the packed exe files.

[Electron builder](https://electron.build) automatically unpacks exe files for us, so all we need to do is to switch the path to take advantage of that.

