### PR TITLE
[Server] Ability to pass an existing socket in config instead of starting a new TCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,8 @@ You can find more examples in the `examples` directory of this repository.
 
     * **debug** - _function_ - Set this to a function that receives a single string argument to get detailed (local) debug information. **Default:** (none)
 
+    * **sock** - _DuplexStream_ - A _DuplexStream_ to pipe to the server instead of creating and using a new TCP server.
+
 #### Connection events
 
 * **authentication**(< _AuthContext_ >ctx) - The client has requested authentication. `ctx.username` contains the client username, `ctx.method` contains the requested authentication method, and `ctx.accept()` and `ctx.reject([< Array >authMethodsLeft[, < Boolean >isPartialSuccess]])` are used to accept or reject the authentication request respectively. `abort` is emitted if the client aborts the authentication request. Other properties/methods available on `ctx` depends on the `ctx.method` of authentication the client has requested:

--- a/lib/server.js
+++ b/lib/server.js
@@ -377,43 +377,58 @@ class Server extends EventEmitter {
       new Client(socket, hostKeys, ident, offer, debug, this, cfg);
     }
 
-    this._srv = new netServer(handleSocket).on('error', (err) => {
-      this.emit('error', err);
-    }).on('listening', () => {
-      this.emit('listening');
-    }).on('close', () => {
-      this.emit('close');
-    });
+    if (cfg.sock) {
+        this._sock = cfg.sock;
+        handleSocket(this._sock);
+    } else {
+      this._srv = new netServer(handleSocket)
+    }
+
+    (this._srv || this._sock).on('error', (err) => {
+        this.emit('error', err);
+      }).on('listening', () => {
+        this.emit('listening');
+      }).on('close', () => {
+        this.emit('close');
+      });
     this._connections = 0;
     this.maxConnections = Infinity;
   }
 
   listen(...args) {
-    this._srv.listen(...args);
-    return this;
+    if (this._srv) {
+      this._srv.listen(...args);
+      return this;
+    }
+
+    throw new Error('Cannot call listen() on server if `sock` was passed in config');
   }
 
   address() {
-    return this._srv.address();
+    return this._srv ? this._srv.address() : this._sock.address();
   }
 
   getConnections(cb) {
-    this._srv.getConnections(cb);
-    return this;
+    if (this._srv) {
+      this._srv.getConnections(cb);
+      return this;
+    }
+
+    throw new Error('Cannot call getConnections() on server if `sock` was passed in config');
   }
 
   close(cb) {
-    this._srv.close(cb);
+    this._srv ? this._srv.close(cb) : this._sock.end(cb)
     return this;
   }
 
   ref() {
-    this._srv.ref();
+    this._srv ? this._srv.ref() : this._sock.ref();
     return this;
   }
 
   unref() {
-    this._srv.unref();
+    this._srv ? this._srv.unref() : this._sock.unref();
     return this;
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -353,7 +353,7 @@ class Server extends EventEmitter {
     const ident = (cfg.ident ? Buffer.from(cfg.ident) : undefined);
     const offer = new KexInit(algorithms);
 
-    this._srv = new netServer((socket) => {
+    const handleSocket = (socket) => {
       if (this._connections >= this.maxConnections) {
         socket.destroy();
         return;
@@ -375,7 +375,9 @@ class Server extends EventEmitter {
 
       // eslint-disable-next-line no-use-before-define
       new Client(socket, hostKeys, ident, offer, debug, this, cfg);
-    }).on('error', (err) => {
+    }
+
+    this._srv = new netServer(handleSocket).on('error', (err) => {
       this.emit('error', err);
     }).on('listening', () => {
       this.emit('listening');


### PR DESCRIPTION
This feature adds the ability to plug an SSH Server instance  to an existing socket, instead of creating a new TCP server and listening on it (useful if the server is behind an existing connection for example).

A similar option already exists in the client (`sock`) so the same name has been picked for consistency, keeping the behavior for the Server object backwards-compatible (if `sock` is not passed, a TCP server is created - same behavior as before).