### PR TITLE
protocol: send ident and CRLF in a single packet

### DIFF
--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -254,8 +254,7 @@ class Protocol {
       );
       if (greeting)
         this._onWrite(greeting);
-      this._onWrite(this._identRaw);
-      this._onWrite(CRLF);
+      this._onWrite(Buffer.concat([this._identRaw, CRLF]));
     });
   }
   _destruct(reason) {


### PR DESCRIPTION
Many older and non-compliant servers (in particular, Cisco switches) will fail to establish a connection when the initial ident is split into multiple TCP packets
