### PR TITLE
lib: support delegated password and key auth

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,7 +83,7 @@ class Client extends EventEmitter {
 
       username: undefined,
       password: undefined,
-      privateKey: undefined,
+      getSigner: undefined,
       tryKeyboard: undefined,
       agent: undefined,
       allowAgentFwd: undefined,
@@ -203,12 +203,13 @@ class Client extends EventEmitter {
       throw new Error('Invalid username');
 
     this.config.password = (typeof cfg.password === 'string'
+                            ? cb => cb(cfg.password)
+                            : typeof cfg.password === 'function'
                             ? cfg.password
                             : undefined);
-    this.config.privateKey = (typeof cfg.privateKey === 'string'
-                              || Buffer.isBuffer(cfg.privateKey)
-                              ? cfg.privateKey
-                              : undefined);
+    this.config.getSigner = (typeof cfg.getSigner === 'function'
+                             ? cfg.getSigner
+                             : undefined);
     this.config.localHostname = (typeof cfg.localHostname === 'string'
                                  ? cfg.localHostname
                                  : undefined);
@@ -222,6 +223,16 @@ class Client extends EventEmitter {
       this.config.agent = cfg.agent;
     else
       this.config.agent = undefined;
+
+    if (typeof cfg.privateKey === 'string' || Buffer.isBuffer(cfg.privateKey)) {
+      if (this.config.getSigner)
+        throw new Error('Cannot specify both a privateKey and getSigner function');
+      const signer = defaultGetSigner(cfg.privateKey, cfg.passphrase);
+      if (signer instanceof Error)
+        throw signer;
+      this.config.getSigner = signer;
+    }
+
     this.config.allowAgentFwd = (cfg.agentForward === true
                                  && this.config.agent !== undefined);
     let authHandler = this.config.authHandler = (
@@ -253,22 +264,6 @@ class Client extends EventEmitter {
     this._agentFwdEnabled = false;
     this._agent = (this.config.agent ? this.config.agent : undefined);
     this._remoteVer = undefined;
-    let privateKey;
-
-    if (this.config.privateKey) {
-      privateKey = parseKey(this.config.privateKey, cfg.passphrase);
-      if (privateKey instanceof Error)
-        throw new Error(`Cannot parse privateKey: ${privateKey.message}`);
-      if (Array.isArray(privateKey)) {
-        // OpenSSH's newer format only stores 1 key for now
-        privateKey = privateKey[0];
-      }
-      if (privateKey.getPrivatePEM() === null) {
-        throw new Error(
-          'privateKey value does not contain a (valid) private key'
-        );
-      }
-    }
 
     let hostVerifier;
     if (typeof cfg.hostVerifier === 'function') {
@@ -377,11 +372,13 @@ class Client extends EventEmitter {
             // TODO: support a `changePrompt()` on `curAuth` that defaults to
             // emitting 'change password' as before
             this.emit('change password', prompt, (newPassword) => {
-              proto.authPassword(
-                this.config.username,
-                this.config.password,
-                newPassword
-              );
+              this.config.password((oldPassword) => {
+                proto.authPassword(
+                  this.config.username,
+                  oldPassword,
+                  newPassword
+                );
+              })
             });
           }
         },
@@ -401,16 +398,24 @@ class Client extends EventEmitter {
               });
             });
           } else if (curAuth.type === 'publickey') {
-            proto.authPK(curAuth.username, curAuth.key, (buf, cb) => {
-              const signature = curAuth.key.sign(buf);
-              if (signature instanceof Error) {
-                signature.message =
-                  `Error signing data with key: ${signature.message}`;
-                signature.level = 'client-authentication';
-                this.emit('error', signature);
+            curAuth.getSigner(signer => {
+              if (signer instanceof Error) {
+                this.emit('error', signer);
                 return tryNextAuth();
               }
-              cb(signature);
+
+              proto.authPK(curAuth.username, signer.publicKey, (buf, cb) => {
+                signer.sign(buf, (signature) => {
+                  if (signature instanceof Error) {
+                    signature.message =
+                      `Error signing data with key: ${signature.message}`;
+                    signature.level = 'client-authentication';
+                    this.emit('error', signature);
+                    return tryNextAuth();
+                  }
+                  cb(signature);
+                });
+              });
             });
           }
         },
@@ -775,13 +780,13 @@ class Client extends EventEmitter {
     const authsAllowed = ['none'];
     if (this.config.password !== undefined)
       authsAllowed.push('password');
-    if (privateKey !== undefined)
+    if (this.config.getSigner !== undefined)
       authsAllowed.push('publickey');
     if (this._agent !== undefined)
       authsAllowed.push('agent');
     if (this.config.tryKeyboard)
       authsAllowed.push('keyboard-interactive');
-    if (privateKey !== undefined
+    if (this.config.getSigner !== undefined
         && this.config.localHostname !== undefined
         && this.config.localUsername !== undefined) {
       authsAllowed.push('hostbased');
@@ -821,13 +826,13 @@ class Client extends EventEmitter {
             nextAuth = { type, username, password: this.config.password };
             break;
           case 'publickey':
-            nextAuth = { type, username, key: privateKey };
+            nextAuth = { type, username, getSigner: this.config.getSigner };
             break;
           case 'hostbased':
             nextAuth = {
               type,
               username,
-              key: privateKey,
+              getSigner: this.config.getSigner,
               localHostname: this.config.localHostname,
               localUsername: this.config.localUsername,
             };
@@ -868,32 +873,33 @@ class Client extends EventEmitter {
         const type = nextAuth.type;
         switch (type) {
           case 'password': {
-            const { password } = nextAuth;
-            if (typeof password !== 'string' && !Buffer.isBuffer(password))
+            let { password } = nextAuth;
+            if (typeof password === 'string' || Buffer.isBuffer(password)) {
+              const passwordStr = password;
+              password = (cb) => cb(passwordStr);
+            }
+            if (typeof password !== 'function')
               return skipAuth('Skipping invalid password auth attempt');
             nextAuth = { type, username, password };
             break;
           }
           case 'publickey': {
-            const key = parseKey(nextAuth.key, nextAuth.passphrase);
-            if (key instanceof Error)
-              return skipAuth('Skipping invalid key auth attempt');
-            if (!key.isPrivateKey())
-              return skipAuth('Skipping non-private key');
-            nextAuth = { type, username, key };
+            // retain compatibility with passing a .key:
+            let getSigner = nextAuth.getSigner || defaultGetSigner(nextAuth.key, nextAuth.passphrase);
+            if (getSigner instanceof Error)
+              return skipAuth(`Skipping key: ${signer.message}`);
+            nextAuth = { type, username, getSigner };
             break;
           }
           case 'hostbased': {
             const { localHostname, localUsername } = nextAuth;
-            const key = parseKey(nextAuth.key, nextAuth.passphrase);
-            if (key instanceof Error
+            let getSigner = nextAuth.getSigner || defaultGetSigner(nextAuth.key, nextAuth.passphrase);
+            if (getSigner instanceof Error
                 || typeof localHostname !== 'string'
                 || typeof localUsername !== 'string') {
               return skipAuth('Skipping invalid hostbased auth attempt');
             }
-            if (!key.isPrivateKey())
-              return skipAuth('Skipping non-private key');
-            nextAuth = { type, username, key, localHostname, localUsername };
+            nextAuth = { type, username, getSigner, localHostname, localUsername };
             break;
           }
           case 'agent': {
@@ -934,27 +940,42 @@ class Client extends EventEmitter {
         const username = curAuth.username;
         switch (curAuth.type) {
           case 'password':
-            proto.authPassword(username, curAuth.password);
+            curAuth.password((password) => proto.authPassword(username, password));
             break;
           case 'publickey':
-            proto.authPK(username, curAuth.key);
-            break;
-          case 'hostbased':
-            proto.authHostbased(username,
-                                curAuth.key,
-                                curAuth.localHostname,
-                                curAuth.localUsername,
-                                (buf, cb) => {
-              const signature = curAuth.key.sign(buf);
-              if (signature instanceof Error) {
-                signature.message =
-                  `Error while signing with key: ${signature.message}`;
-                signature.level = 'client-authentication';
-                this.emit('error', signature);
+            curAuth.getSigner((signer) => {
+              if (signer instanceof Error) {
+                this.emit('error', signer);
                 return tryNextAuth();
               }
 
-              cb(signature);
+              proto.authPK(username, signer.publicKey);
+            });
+            break;
+          case 'hostbased':
+            curAuth.getSigner((signer) => {
+              if (signer instanceof Error) {
+                this.emit('error', signer);
+                return tryNextAuth();
+              }
+
+              proto.authHostbased(username,
+                                  signer.publicKey,
+                                  curAuth.localHostname,
+                                  curAuth.localUsername,
+                                  (buf, cb) => {
+                signer.sign(buf, (signature) => {
+                  if (signature instanceof Error) {
+                    signature.message =
+                      `Error while signing with key: ${signature.message}`;
+                    signature.level = 'client-authentication';
+                    this.emit('error', signature);
+                    return tryNextAuth();
+                  }
+
+                  cb(signature);
+                });
+              });
             });
             break;
           case 'agent':
@@ -1912,6 +1933,26 @@ function makeSimpleAuthHandler(authList) {
       return false;
     return authList[a++];
   };
+}
+
+function defaultGetSigner(key, passphrase) {
+  let privateKey = parseKey(key, passphrase);
+  if (privateKey instanceof Error)
+    return privateKey;
+  if (Array.isArray(privateKey)) {
+    // OpenSSH's newer format only stores 1 key for now
+    privateKey = privateKey[0];
+  }
+  if (privateKey.getPrivatePEM() === null) {
+    return new Error(
+      'privateKey value does not contain a (valid) private key'
+    );
+  }
+
+  return (cb) => cb({
+    publicKey: privateKey.getPublicSSH(),
+    sign: (buf, cb2) => cb2(privateKey.sign(buf)),
+  });
 }
 
 function hostKeysProve(client, keys_, cb) {


### PR DESCRIPTION
We have a scenario where we want to "delegate" authentication to a different machine: we want to avoid asking for a password unless it's needed, and avoid having the private key pass through the connecting machine at all. Previously `ssh2` only allowed the password and privateKey to be provided directly at the time the client was instantiated.

This PR allows two things:

- `password` to be given as a function which calls back with the user-provided password
- a `getSigner` function to be provided instead of a private key. This is modelled off Go SSH's [PublicKeysCallback](https://pkg.go.dev/golang.org/x/crypto/ssh#PublicKeysCallback), and likewise calls back with a [Signer](https://pkg.go.dev/golang.org/x/crypto/ssh#Signer) -- an object containing the public key, and a signing function which can be delegated in turn.

I've updated the library and tests, but not docs yet pending your feedback or thoughts on this approach.

Thanks! 🙂 