### PR TITLE
fix: nan and cpu-features should be  really optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,21 @@
   },
   "devDependencies": {
     "@mscdex/eslint-config": "^1.0.0",
-    "eslint": "^7.0.0"
+    "cpu-features": "0.0.2",
+    "eslint": "^7.0.0",
+    "nan": "^2.15.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "cpu-features": "0.0.2",
     "nan": "^2.15.0"
+  },
+  "peerDependenciesMeta": {
+    "cpu-features": {
+      "optional": true
+    },
+    "nan": {
+      "optional": true
+    }
   },
   "scripts": {
     "install": "node install.js",


### PR DESCRIPTION
## Changes

Moving "nan" and "cpu-features" to peerDependencies (optional). While "optionalDependencies" looks the way to do it, it's actually not really what's intended here (imho)

## Will fix

Prevent errors (in ci or whenever cmake is not there) and make install faster when you actually don't need cpu-features or nan.

![image](https://user-images.githubusercontent.com/259798/137488360-4728435f-57be-466f-865c-a28de0930670.png)

## Related

- https://github.com/mscdex/ssh2/issues/1030
- https://github.com/mscdex/ssh2/issues/1074
- https://github.com/mscdex/ssh2/issues/1055
- https://github.com/mscdex/ssh2/issues/1015
(...)

## Breaking changes ?

Moving to peerDependencies is the way to go (see context below, I can give other examples or threads). 

If a dependent package used to rely on on 'nan' or 'cpu-features' without actually declare them in their deps, they'll have to do.

I have no idea how many packages actually rely on them, but as ssh2 is widely used (https://www.npmjs.com/package/ssh2), it might be safe to create a major version and add to the migration something like:

> If you were relying on cpu-features or nan, they won't be installed by default. You can explicitly add them to your deps: `yarn add cpu-features@0.0.2` and/or  `yarn add nan@^2.15.0`



## Context

"optionalDependencies" might not be what we're looking.


- npm v6: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#optionaldependencies
- npm v7: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#optionaldependencies
- yarn v1: https://classic.yarnpkg.com/en/docs/dependency-types#toc-optionaldependencies
- yarn berry: https://yarnpkg.com/configuration/manifest#optionalDependencies


Quoting yarn doc:

> Similar to the dependencies field, except that these entries will not be required to build properly should they have any build script. Note that such dependencies must still be resolvable and fetchable (otherwise we couldn't store it in the lockfile, which could lead to non-reproducible installs) - only the build step is optional.
>
> This field is usually not what you're looking for, unless you depend on the fsevents package. If you need a package to be required only when a specific feature is used then use an optional peer dependency. Your users will have to satisfy it should they use the feature, but it won't cause the build errors to be silently swallowed when the feature is needed.

Per definition "optional" will still install the packages, and often the build step is actually failing.... (in CI for example)

## Why peerDependencies and meta ?

To achieve the expected goal, the idea is to use `peerDependencies` and `peerDependenciesMeta (with optional)`. It's supported in a consistent way by mainstream package managers:

- npm v6 - https://docs.npmjs.com/cli/v6/configuring-npm/package-json#peerdependencies
- npm v7 - https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies (+ [meta](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta))
- yarn v1 - https://classic.yarnpkg.com/en/docs/dependency-types#toc-peerdependencies
- yarn berry - https://yarnpkg.com/configuration/manifest#peerDependencies
- pnpm - https://pnpm.io/package_json#peerdependenciesmeta

