### PR TITLE
protocol/SFTP: Manual error emit on write error when autoClose = true.

### DIFF
--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -3695,8 +3695,10 @@ WriteStream.prototype._write = function(data, encoding, cb) {
                   this.pos,
                   (er, bytes) => {
     if (er) {
-      if (this.autoClose)
+      if (this.autoClose) {
+        this.emit('error', er); // er is swalloed by destroy(), emit manually.
         this.destroy();
+      }
       return cb(er);
     }
     this.bytesWritten += bytes;


### PR DESCRIPTION
When using an SFTP writable stream with `autoClose = false`, errors during the writing process are relayed to the error listeners as they are reported via callback from `WriteStream.prototype._write`. When `autoClose = true`, the errors don't make it to listeners because of the call to `this.destroy()`. This change manually emits the error when `autoClose = true` for visibility to library users.