### PR TITLE
Fix use case connect to first with publicKey then password

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -774,10 +774,10 @@ class Client extends EventEmitter {
     let curPartial = null;
     let curAuthsLeft = null;
     const authsAllowed = ['none'];
-    if (this.config.password !== undefined)
-      authsAllowed.push('password');
     if (privateKey !== undefined)
       authsAllowed.push('publickey');
+    if (this.config.password !== undefined)
+      authsAllowed.push('password');
     if (this._agent !== undefined)
       authsAllowed.push('agent');
     if (this.config.tryKeyboard)


### PR DESCRIPTION
Reordering the authentication methods allows to connect to a remote host requiring both pubkey and password successively.
