### PR TITLE
fix: return `this` from `destroy()`

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -214,6 +214,7 @@ class Channel extends DuplexStream {
   destroy() {
     this.end();
     this.close();
+    return this;
   }
 
   // Session type-specific methods =============================================


### PR DESCRIPTION
For consistency with Node readable stream implementation, `destroy()` should return `this` - https://nodejs.org/api/stream.html#readabledestroyerror

**Context**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473