### PR TITLE
protocol/keyParser: fix return error

### DIFF
--- a/lib/protocol/keyParser.js
+++ b/lib/protocol/keyParser.js
@@ -595,6 +595,8 @@ OpenSSH_Private.prototype = BaseKey;
     } else {
       ret = [];
     }
+    if (ret instanceof Error)
+      return ret;
     // This will need to change if/when OpenSSH ever starts storing multiple
     // keys in their key files
     return ret[0];

--- a/test/test-protocol-keyparser.js
+++ b/test/test-protocol-keyparser.js
@@ -85,14 +85,29 @@ readdirSync(BASE_PATH).forEach((name) => {
   }
 
   if (isEncrypted && !isPublic) {
-    // Make sure parsing encrypted keys without a passhprase or incorrect
-    // passphrase results in an appropriate error
+    // Make sure parsing encrypted keys without a passphrase results in an
+    // appropriate error
     const err = parseKey(key);
     if (!(err instanceof Error))
       failMsg(name, 'Expected error during parse without passphrase', true);
     if (!/no passphrase/i.test(err.message)) {
       failMsg(name,
               `Error during parse without passphrase: ${err.message}`,
+              true);
+    }
+
+    // Make sure parsing encrypted keys with an incorrect passphrase results in
+    // an appropriate error
+    const errIncPass = parseKey(key, "incorrectPassphrase");
+    if (!(errIncPass instanceof Error))
+      failMsg(name,
+              'Expected error during parse with an incorrect passphrase',
+              true);
+    if (!/bad passphrase\?|unable to authenticate data/i
+        .test(errIncPass.message)) {
+      failMsg(name,
+              'Error during parse with an incorrect passphrase: '
+                + errIncPass.message,
               true);
     }
   }

--- a/test/test-protocol-keyparser.js
+++ b/test/test-protocol-keyparser.js
@@ -98,11 +98,12 @@ readdirSync(BASE_PATH).forEach((name) => {
 
     // Make sure parsing encrypted keys with an incorrect passphrase results in
     // an appropriate error
-    const errIncPass = parseKey(key, "incorrectPassphrase");
-    if (!(errIncPass instanceof Error))
+    const errIncPass = parseKey(key, 'incorrectPassphrase');
+    if (!(errIncPass instanceof Error)) {
       failMsg(name,
               'Expected error during parse with an incorrect passphrase',
               true);
+    }
     if (!/bad passphrase\?|unable to authenticate data/i
         .test(errIncPass.message)) {
       failMsg(name,


### PR DESCRIPTION
When you provide a private key in new OpenSSH format with a **wrong passphrase** to `utils.parseKey` ([code](https://github.com/mscdex/ssh2/blob/6b4c64ce5c16f488d90b87997aa0f19c871abe2f/lib/protocol/keyParser.js#L1413)), it returns undefined instead of returning the `Error` ([code](https://github.com/mscdex/ssh2/blob/6b4c64ce5c16f488d90b87997aa0f19c871abe2f/lib/protocol/keyParser.js#L627)).

I think this is an unintended side effect from the change in commit [3ef3f3ee](https://github.com/mscdex/ssh2/commit/3ef3f3ee55e91bda19c90ff0b716522b0eccfaaa#).