### PR TITLE
Allow passwords to be sent as the callback to a 'password' event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,8 @@ You can find more examples in the `examples` directory of this repository.
 
     * **tryKeyboard** - _boolean_ - Try keyboard-interactive user authentication if primary user authentication method fails. If you set this to `true`, you need to handle the `keyboard-interactive` event. **Default:** `false`
 
+    * **passwordPrompt** - _boolean_ - Emit a password event that takes a callback with the password instead of using the password supplied in the password field.  You need to handle the `password` event. **Default** `false`
+
     * **username** - _string_ - Username for authentication. **Default:** (none)
 
 * **end**() - _(void)_ - Disconnects the socket.

--- a/lib/client.js
+++ b/lib/client.js
@@ -85,6 +85,7 @@ class Client extends EventEmitter {
       password: undefined,
       privateKey: undefined,
       tryKeyboard: undefined,
+      passwordPrompt: undefined,
       agent: undefined,
       allowAgentFwd: undefined,
       authHandler: undefined,
@@ -216,6 +217,7 @@ class Client extends EventEmitter {
                                  ? cfg.localUsername
                                  : undefined);
     this.config.tryKeyboard = (cfg.tryKeyboard === true);
+    this.config.passwordPrompt = (cfg.passwordPrompt === true);
     if (typeof cfg.agent === 'string' && cfg.agent.length)
       this.config.agent = createAgent(cfg.agent);
     else if (isAgent(cfg.agent))
@@ -774,7 +776,7 @@ class Client extends EventEmitter {
     let curPartial = null;
     let curAuthsLeft = null;
     const authsAllowed = ['none'];
-    if (this.config.password !== undefined)
+    if ((this.config.password !== undefined) || this.config.passwordPrompt)
       authsAllowed.push('password');
     if (privateKey !== undefined)
       authsAllowed.push('publickey');
@@ -819,6 +821,16 @@ class Client extends EventEmitter {
         const username = this.config.username;
         switch (type) {
           case 'password':
+            if(this.config.passwordPrompt) {
+              this.emit('password', (newPassword) => {
+                nextAuth = { 
+                  type, 
+                  username, 
+                  password: newPassword
+                }; 
+              });
+              break;
+            }
             nextAuth = { type, username, password: this.config.password };
             break;
           case 'publickey':

--- a/test/test-userauth.js
+++ b/test/test-userauth.js
@@ -184,6 +184,41 @@ const debug = false;
     process.nextTick(done, newPassword);
   }));
 }
+{
+  const username = 'Password User';
+  const password = 'hi mom';
+  const { client, server } = setup(
+    'Password (prompt)',
+    {
+      client: { username, passwordPrompt: true },
+      server: serverCfg,
+
+      debug,
+    }
+  );
+
+  server.on('connection', mustCall((conn) => {
+    let authAttempt = 0;
+    conn.on('authentication', mustCall((ctx) => {
+      assert(ctx.username === username,
+             `Wrong username: ${ctx.username}`);
+      if (++authAttempt === 1) {
+        assert(ctx.method === 'none', `Wrong auth method: ${ctx.method}`);
+        return ctx.reject();
+      }
+      assert(ctx.method === 'password',
+             `Wrong auth method: ${ctx.method}`);
+      assert(ctx.password === password,
+        `Wrong password: ${ctx.password}`);
+      ctx.accept();
+    }, 2)).on('ready', mustCall(() => {
+      conn.end();
+    }));
+  }));
+  client.on('password', mustCall((cb) => {
+      cb(password);
+  }));
+}
 
 
 // Hostbased ===================================================================


### PR DESCRIPTION
We use the SSH client as a way to authenticate users to a web server
The users are on a remote machine.

This is similar to keyboard-interactive, but for passwords only.  Some systems have ChallengeResponse disabled, and PasswordAuthentication enabled in sshd

Password prompt allows us to proxy over their remote connections and use SSH over the web in the same manner you would if you had a desktop ssh connection.  

This is helpful if you are using multiple authMethods (privateKey, keyboardInteractive, password).  You only want to prompt for the password once it is needed.

