### PR TITLE
add aes128-gcm and aes256-gcm to supported ciphers

### DIFF
--- a/lib/protocol/constants.js
+++ b/lib/protocol/constants.js
@@ -105,6 +105,8 @@ const SUPPORTED_CIPHER = DEFAULT_CIPHER.concat([
   'aes128-cbc',
   'blowfish-cbc',
   '3des-cbc',
+  'aes128-gcm',
+  'aes256-gcm',
 
   // http://tools.ietf.org/html/rfc4345#section-4:
   'arcfour256',

--- a/test/test-misc-client-server.js
+++ b/test/test-misc-client-server.js
@@ -1224,6 +1224,8 @@ const setup = setupSimple.bind(undefined, debug);
       'aes256-ctr',
       'aes128-gcm@openssh.com',
       'aes256-gcm@openssh.com',
+      'aes128-gcm',
+      'aes256-gcm',
     ],
   },
   { desc: 'remove/append/prepend (strings)',


### PR DESCRIPTION
Closes #1100 by adding 'aes128-gcm' and 'aes256-gcm' as supported ciphers