### PR TITLE
Properly close connection on EOF

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -207,6 +207,11 @@ class Session extends EventEmitter {
         state: 'open'
       }
     };
+
+    this.on('eof', () => {
+      if (this._channel)
+        this._channel.end();
+    });
   }
 }
 


### PR DESCRIPTION
I ran into #1029 . The workaround in that issue works for most clients but fails with PuTTY scp (`pscp`). Looking into it further, it seems that these clients send `CHANNEL_EOF` when `exit`, `bye`, or `quit` is executed. When the server does not close the connection, the session hangs. This PR addresses the issue by handling the `eof` signal and properly closing the connection. This change has been tested to work for `sftp`, `pscp`, `WinSCP`, and `paramiko`.

I'm not completely sure that this is the correct place, but hopefully if it is not, it is helpful in pointing to the correct place to fix this.