### PR TITLE
client: make destroy() always destroy the socket

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1086,7 +1086,7 @@ class Client extends EventEmitter {
   }
 
   destroy() {
-    this._sock && isWritable(this._sock) && this._sock.destroy();
+    this._sock && this._sock.destroy();
     return this;
   }
 


### PR DESCRIPTION
If client.destroy() is called, always destroy the underlying socket so
that file descriptor is freed. This matches behavior of node's Socket and
Writable.

Previous behavior made this conditional on writability of the socket.
If the socket wasn't writable, then client.destroy() wouldn't actually
destroy the socket, the file descriptor would remain open, and the
node process would hang on exit.. It might timeout after 15 minutes, if
you're lucky.

fixes #1124