### PR TITLE
Fix: Destroys socket so long as it exists

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1086,7 +1086,7 @@ class Client extends EventEmitter {
   }
 
   destroy() {
-    this._sock && isWritable(this._sock) && this._sock.destroy();
+    this._sock && this._sock.destroy();
     return this;
   }
 


### PR DESCRIPTION
https://github.com/mscdex/ssh2/issues/1124

Seems as though the socket can still receive data. If there's a specific reason why destroy isn't called regardless of writable state I'm willing to listen