### PR TITLE
Untested fix: import from constants instead of itself

### DIFF
--- a/lib/protocol/utils.js
+++ b/lib/protocol/utils.js
@@ -2,7 +2,7 @@
 
 const Ber = require('asn1').Ber;
 
-let DISCONNECT_REASON;
+const { DISCONNECT_REASON } = require('./constants.js');
 
 const FastBuffer = Buffer[Symbol.species];
 const TypedArrayFill = Object.getPrototypeOf(Uint8Array.prototype).fill;
@@ -170,8 +170,6 @@ module.exports = {
   makeError,
   doFatalError: (protocol, msg, level, reason) => {
     let err;
-    if (DISCONNECT_REASON === undefined)
-      ({ DISCONNECT_REASON } = require('./utils.js'));
     if (msg instanceof Error) {
       // doFatalError(protocol, err[, reason])
       err = msg;


### PR DESCRIPTION
Every where else but utils seems to be importing from the `/lib/protocol/constants.js` except for util which for some reason is importing from itself but never actually defines it. I'm suprised this isn't throwing an error

https://github.com/mscdex/ssh2/issues/1081