### PR TITLE
fix: fatal error due to undefined DISCONNECT_REASON

### DIFF
--- a/lib/protocol/utils.js
+++ b/lib/protocol/utils.js
@@ -171,7 +171,7 @@ module.exports = {
   doFatalError: (protocol, msg, level, reason) => {
     let err;
     if (DISCONNECT_REASON === undefined)
-      ({ DISCONNECT_REASON } = require('./utils.js'));
+      ({ DISCONNECT_REASON } = require('./constants.js'));
     if (msg instanceof Error) {
       // doFatalError(protocol, err[, reason])
       err = msg;


### PR DESCRIPTION
## Changes

In `lib/protocol/utils.js` require `constants.js` instead of `utils.js` when loading `DISCONNECT_REASON`

## Will fix

`DISCONNECT_REASON` is undefined in `lib/protocol/utils.js` due to requiring `utils.js` instead of `constants.js`. This results in the following error:

```
TypeError: Cannot read property 'PROTOCOL_ERROR' of undefined
    at doFatalError (/usr/src/app/node_modules/ssh2/lib/protocol/utils.js:187:34)
    at Array.1 (/usr/src/app/node_modules/ssh2/lib/protocol/handlers.misc.js:42:14)
    at Protocol.onKEXPayload (/usr/src/app/node_modules/ssh2/lib/protocol/kex.js:1744:36)
    at NullDecipher.decrypt (/usr/src/app/node_modules/ssh2/lib/protocol/crypto.js:612:26)
    at Protocol.parsePacket [as _parse] (/usr/src/app/node_modules/ssh2/lib/protocol/Protocol.js:1994:25)
    at Protocol.parse (/usr/src/app/node_modules/ssh2/lib/protocol/Protocol.js:293:16)
    at Socket.<anonymous> (/usr/src/app/node_modules/ssh2/lib/server.js:1207:17)
    at Socket.emit (events.js:314:20)
    at addChunk (_stream_readable.js:297:12)
    at readableAddChunk (_stream_readable.js:272:9)
    at Socket.Readable.push (_stream_readable.js:213:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
```