### PR TITLE
feat: Windows - compile sshcrypto for OpenSSL3

### DIFF
--- a/lib/protocol/crypto/binding.gyp
+++ b/lib/protocol/crypto/binding.gyp
@@ -18,6 +18,30 @@
         'OPENSSL_API_COMPAT=0x10100000L',
         'REAL_OPENSSL_MAJOR=<(real_openssl_major)',
       ],
+
+      'conditions': [
+        [ 'OS=="win"', {
+          'conditions': [
+            ['target_arch=="x64"', {
+              'variables': {
+                'openssl_root%': 'C:/Program Files/OpenSSL-Win64'
+                },
+            }, {
+              'variables': {
+                'openssl_root%': 'C:/Program Files/OpenSSL-Win32'
+                },
+            }],
+          ],
+          'libraries': [
+            # libeay32.lib for OpenSSL < 3
+            '-l<(openssl_root)/lib/libcrypto.lib',
+          ],
+          'include_dirs': [
+            '<(openssl_root)/include',
+          ],
+        }]
+      ],
+
     },
   ],
 }


### PR DESCRIPTION
This PR implements building sshcrypto against OpenSSL3 on Windows according to https://github.com/nodejs/node-gyp/blob/master/docs/Linking-to-OpenSSL.md

It's still necessary to install OpenSSL 3 (developer version) from http://slproweb.com/products/Win32OpenSSL.html