### PR TITLE
NEW return this from SFTP.destroy() and SFTP.end()

### DIFF
--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -282,12 +282,14 @@ class SFTP extends EventEmitter {
 
   end() {
     this.destroy();
+    return this;
   }
   destroy() {
     if (this.outgoing.state === 'open' || this.outgoing.state === 'eof') {
       this.outgoing.state = 'closing';
       this._protocol.channelClose(this.outgoing.id);
     }
+    return this;
   }
   _init() {
     this._init = noop;


### PR DESCRIPTION
return `this` from `SFTP.end()` and `SFTP.destroy()` to make the API more consistent with native streams.