### PR TITLE
Fix partial success not passing when using agent authentication

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -362,11 +362,28 @@ class Client extends EventEmitter {
         USERAUTH_FAILURE: (p, authMethods, partialSuccess) => {
           if (curAuth.type === 'agent') {
             const pos = curAuth.agentCtx.pos();
-            debug && debug(`Client: Agent key #${pos + 1} failed`);
-            return tryNextAgentKey();
+            if (partialSuccess) {
+              const key = curAuth.agentCtx.currentKey();
+              proto.authPK(curAuth.username, key, (buf, cb) => {
+              curAuth.agentCtx.sign(key, buf, {}, (err, signed) => {
+                if (err) {
+                  err.level = 'agent';
+                  this.emit('error', err);
+                } else {
+                  return cb(signed);
+                }
+
+                return tryNextAgentKey();
+              });
+            });
+            } else {
+              debug && debug(`Client: Agent key #${pos + 1} failed`);
+              return tryNextAgentKey();
+            }
           }
 
-          debug && debug(`Client: ${curAuth.type} auth failed`);
+          debug && debug(`Client: ${curAuth.type} auth ${partialSuccess
+          ? 'succeeded with partial success' : 'failed'}`);
 
           curPartial = partialSuccess;
           curAuthsLeft = authMethods;


### PR DESCRIPTION
Currently the partialSuccess variable is ignored when using agent authentication, and the client skips to the next agent key. This causes connections to fail when using an agent key + a second authentication method (like 2FA using keyboard-interactive). 

With this PR, the client skips to the next authentication method instead of the next agent key when receiving a partial success.