### PR TITLE
remove BAD_DHGEX compatibility flag

### DIFF
--- a/lib/protocol/constants.js
+++ b/lib/protocol/constants.js
@@ -155,7 +155,6 @@ const SUPPORTED_COMPRESSION = DEFAULT_COMPRESSION.concat([
 
 
 const COMPAT = {
-  BAD_DHGEX: 1 << 0,
   OLD_EXIT: 1 << 1,
   DYN_RPORT_BUG: 1 << 2,
   BUG_DHGEX_LARGE: 1 << 3,
@@ -326,7 +325,6 @@ module.exports = {
 
   COMPAT,
   COMPAT_CHECKS: [
-    [ 'Cisco-1.25', COMPAT.BAD_DHGEX ],
     [ /^Cisco-1\./, COMPAT.BUG_DHGEX_LARGE ],
     [ /^[0-9.]+$/, COMPAT.OLD_EXIT ], // old SSH.com implementations
     [ /^OpenSSH_5\.\d+/, COMPAT.DYN_RPORT_BUG ],

--- a/lib/protocol/kex.js
+++ b/lib/protocol/kex.js
@@ -73,44 +73,8 @@ function kexinit(self) {
     uint32       0 (reserved for future extension)
   */
 
-  let payload;
-  if (self._compatFlags & COMPAT.BAD_DHGEX) {
-    const entry = self._offer.lists.kex;
-    let kex = entry.array;
-    let found = false;
-    for (let i = 0; i < kex.length; ++i) {
-      if (kex[i].includes('group-exchange')) {
-        if (!found) {
-          found = true;
-          // Copy array lazily
-          kex = kex.slice();
-        }
-        kex.splice(i--, 1);
-      }
-    }
-    if (found) {
-      let len = 1 + 16 + self._offer.totalSize + 1 + 4;
-      const newKexBuf = Buffer.from(kex.join(','));
-      len -= (entry.buffer.length - newKexBuf.length);
-
-      const all = self._offer.lists.all;
-      const rest = new Uint8Array(
-        all.buffer,
-        all.byteOffset + 4 + entry.buffer.length,
-        all.length - (4 + entry.buffer.length)
-      );
-
-      payload = Buffer.allocUnsafe(len);
-      writeUInt32BE(payload, newKexBuf.length, 17);
-      payload.set(newKexBuf, 17 + 4);
-      payload.set(rest, 17 + 4 + newKexBuf.length);
-    }
-  }
-
-  if (payload === undefined) {
-    payload = Buffer.allocUnsafe(1 + 16 + self._offer.totalSize + 1 + 4);
-    self._offer.copyAllTo(payload, 17);
-  }
+  const payload = Buffer.allocUnsafe(1 + 16 + self._offer.totalSize + 1 + 4);
+  self._offer.copyAllTo(payload, 17);
 
   self._debug && self._debug('Outbound: Sending KEXINIT');
 
@@ -198,19 +162,6 @@ function handleKexInit(self, payload) {
   const remote = init;
 
   let localKex = local.lists.kex.array;
-  if (self._compatFlags & COMPAT.BAD_DHGEX) {
-    let found = false;
-    for (let i = 0; i < localKex.length; ++i) {
-      if (localKex[i].indexOf('group-exchange') !== -1) {
-        if (!found) {
-          found = true;
-          // Copy array lazily
-          localKex = localKex.slice();
-        }
-        localKex.splice(i--, 1);
-      }
-    }
-  }
 
   let clientList;
   let serverList;


### PR DESCRIPTION
Removing `BAD_DHGEX` compatibility flag:

* tested against Cisco 1.25 device, all is working fine, see the attached log with `show version` command executed
* also checked `npm test`, there is no difference between `main` and `BAD_DHGEX` branches.

Let me know if more testing is needed.
Please kindly consider merging the pull request.

```
Custom crypto binding available
Local ident: 'SSH-2.0-ssh2js1.11.0'
Client: Trying 10.77.255.110 on port 22 ...
Socket connected
Remote ident: 'SSH-1.99-Cisco-1.25'
Outbound: Sending KEXINIT
Inbound: Handshake in progress
Handshake: (local) KEX method: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group1-sha1,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512
Handshake: (remote) KEX method: diffie-hellman-group-exchange-sha1
Handshake: KEX algorithm: diffie-hellman-group-exchange-sha1
Handshake: (local) Host key format: ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256,ssh-rsa,ssh-dss
Handshake: (remote) Host key format: ssh-rsa
Handshake: Host key format: ssh-rsa
Handshake: (local) C->S cipher: aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes256-cbc,aes192-cbc,aes128-cbc,blowfish-cbc,3des-cbc,arcfour256,arcfour128,cast128-cbc,arcfour,chacha20-poly1305@openssh.com
Handshake: (remote) C->S cipher: aes128-ctr,aes192-ctr,aes256-ctr
Handshake: C->S Cipher: aes128-ctr
Handshake: (local) S->C cipher: aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes256-cbc,aes192-cbc,aes128-cbc,blowfish-cbc,3des-cbc,arcfour256,arcfour128,cast128-cbc,arcfour,chacha20-poly1305@openssh.com
Handshake: (remote) S->C cipher: aes128-ctr,aes192-ctr,aes256-ctr
Handshake: S->C cipher: aes128-ctr
Handshake: (local) C->S MAC: hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-md5,hmac-sha2-256-96,hmac-sha2-512-96,hmac-ripemd160,hmac-sha1-96,hmac-md5-96
Handshake: (remote) C->S MAC: hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-96
Handshake: C->S MAC: hmac-sha2-256
Handshake: (local) S->C MAC: hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-md5,hmac-sha2-256-96,hmac-sha2-512-96,hmac-ripemd160,hmac-sha1-96,hmac-md5-96
Handshake: (remote) S->C MAC: hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-96
Handshake: S->C MAC: hmac-sha2-256
Handshake: (local) C->S compression: none,zlib@openssh.com,zlib
Handshake: (remote) C->S compression: none
Handshake: C->S compression: none
Handshake: (local) S->C compression: none,zlib@openssh.com,zlib
Handshake: (remote) S->C compression: none
Handshake: S->C compression: none
Outbound: Sending KEXDH_GEX_REQUEST
Received DH GEX Group
Outbound: Sending KEXDH_GEX_INIT
Received DH GEX Reply
Received DH Reply
Host accepted by default (no verification)
Host accepted (verified)
Outbound: Sending NEWKEYS
Inbound: NEWKEYS
Verifying signature ...
Verified signature
Handshake completed
Outbound: Sending SERVICE_REQUEST (ssh-userauth)
Inbound: Received SERVICE_ACCEPT (ssh-userauth)
Outbound: Sending USERAUTH_REQUEST (none)
Inbound: Received USERAUTH_FAILURE (publickey,keyboard-interactive,password)
Client: none auth failed
Outbound: Sending USERAUTH_REQUEST (password)
Inbound: Received USERAUTH_SUCCESS
Client :: ready
Outbound: Sending CHANNEL_OPEN (r:0, session)
Inbound: CHANNEL_OPEN_CONFIRMATION (r:0, s:3)
Outbound: Sending CHANNEL_REQUEST (r:3, exec: show version)
Inbound: CHANNEL_SUCCESS (r:0)
Inbound: CHANNEL_DATA (r:0, 2430)
STDOUT: Cisco IOS XE Software, Version 16.06.05
Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.6.5, RELEASE SOFTWARE (fc3)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2018 by Cisco Systems, Inc.
Compiled Mon 10-Dec-18 13:07 by mcpre


Cisco IOS-XE software, Copyright (c) 2005-2018 by cisco Systems, Inc.
All rights reserved.  Certain components of Cisco IOS-XE software are
licensed under the GNU General Public License ("GPL") Version 2.0.  The
software code licensed under GPL Version 2.0 is free software that comes
with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
GPL code under the terms of GPL Version 2.0.  For more details, see the
documentation or "License Notice" file accompanying the IOS-XE software,
or the applicable URL provided on the flyer accompanying the IOS-XE
software.


ROM: IOS-XE ROMMON

L77R11-LEAF5 uptime is 5 weeks, 6 days, 10 hours, 57 minutes
Uptime for this control processor is 5 weeks, 6 days, 10 hours, 59 minutes
System returned to ROM by reload
System image file is "bootflash:packages.conf"
Last reload reason: reload



This product contains cryptographic features and is subject to United
States and local country laws governing import, export, transfer and
use. Delivery of Cisco cryptographic products does not imply
third-party authority to import, export, distribute or use encryption.
Importers, exporters, distributors and users are responsible for
compliance with U.S. and local country laws. By using this product you
agree to comply with applicable laws and regulations. If you are unable
to comply with U.S. and local laws, return this product immediately.

A summary of U.S. laws governing Cisco cryptographic products may be found at:
http://www.cisco.com/wwl/export/crypto/tool/stqrg.html

If you require further assistance please contact us by sending email to
export@cisco.com.

License Level: ax
License Type: Default. No valid license found.
Next reload license Level: ax

cisco CSR1000V (VXE) processor (revision VXE) with 2190079K/3075K bytes of memory.
Processor board ID 9PP06RHS9ZA
4 Gigabit Ethernet interfaces
32768K bytes of non-volatile configuration memory.
3984864K bytes of physical memory.
7774207K bytes of virtual hard disk at bootflash:.
0K bytes of WebUI ODM Files at webui:.

Configuration register is 0x2102

Inbound: CHANNEL_REQUEST (r:0, exit-status: 0)
Inbound: CHANNEL_EOF (r:0)
Inbound: CHANNEL_CLOSE (r:0)
Outbound: Sending CHANNEL_CLOSE (r:3)
Stream :: close :: code: 0, signal: undefined
Outbound: Sending DISCONNECT (11)
Socket ended
Socket closed
```