### PR TITLE
Replace cpu-features to @napi-rs/sysinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Changes (breaking or otherwise) in v1.0.0 can be found [here](https://github.com
 
 * [node.js](http://nodejs.org/) -- v10.16.0 or newer
   * node v12.0.0 or newer for Ed25519 key support
-* (Optional) [`cpu-features`](https://github.com/mscdex/cpu-features) is set as an optional package dependency (you do not need to install it explicitly/separately from `ssh2`) that will be automatically built and used if possible. See the project's documentation for its own requirements.
+* (Optional) [`@napi-rs/sysinfo`](https://github.com/Brooooooklyn/sysinfo) is set as an optional package dependency (you do not need to install it explicitly/separately from `ssh2`) that will be automatically built and used if possible. See the project's documentation for its own requirements.
   * This addon is currently used to help generate an optimal default cipher list
 
 ## Installation

--- a/lib/protocol/constants.js
+++ b/lib/protocol/constants.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 
 let cpuInfo;
 try {
-  cpuInfo = require('cpu-features')();
+  cpuInfo = require('@napi-rs/sysinfo').cpuFeatures();
 } catch {}
 
 const { bindingAvailable, CIPHER_INFO, MAC_INFO } = require('./crypto.js');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint": "^7.0.0"
   },
   "optionalDependencies": {
-    "cpu-features": "~0.0.4",
+    "@napi-rs/sysinfo": "~0.0.1",
     "nan": "^2.16.0"
   },
   "scripts": {


### PR DESCRIPTION
Compare to `cpu-features`, the `@napi-rs/sysinfo` is easier to install (prebuilt).