### PR TITLE
Allow alternate sftp-server paths for client connections 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1605,7 +1605,7 @@ class Client extends EventEmitter {
         }
 
         sftp.on('ready', onReady)
-        .on('error', onError)
+            .on('error', onError)
             .on('exit', onExit)
             .on('close', onExit);
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1554,7 +1554,7 @@ class Client extends EventEmitter {
     return this;
   }
 
-  sftp(cb) {
+  sftp(cb, { command } = {}) {
     if (!this._sock || !isWritable(this._sock))
       throw new Error('Not connected');
 
@@ -1564,7 +1564,7 @@ class Client extends EventEmitter {
         return;
       }
 
-      reqSubsystem(sftp, 'sftp', (err, sftp_) => {
+      const sftpCb = (err, sftp_) => {
         if (err) {
           cb(err);
           return;
@@ -1605,12 +1605,18 @@ class Client extends EventEmitter {
         }
 
         sftp.on('ready', onReady)
-            .on('error', onError)
+        .on('error', onError)
             .on('exit', onExit)
             .on('close', onExit);
 
         sftp._init();
-      });
+      };
+
+      if (command) {
+        reqExec(sftp, command, {}, sftpCb);
+      } else {
+        reqSubsystem(sftp, 'sftp', sftpCb);
+      }
     });
 
     return this;


### PR DESCRIPTION
This PR allows the client to select an alternate path for clients to connect sftp to.

A usage of this SSH facility is to use alternate sftp-servers or to do privilege escalation on systems that support it, the OpenSSH SFTP tool supports this with the `-s` flag.

Usage (in OpenSSH SFTP):
` sftp -s "/usr/bin/sudo /usr/libexec/sftp-server" -p 22 frylock@192.168.100.100`

Usage in SSH2 lib:
```js

const { Client } = require('ssh2');

const conn = new Client();
conn.on('ready', () => {
  console.log('Client :: ready');
  conn.sftp((err, sftp) => {
    if (err) throw err;
    sftp.readdir('foo', (err, list) => {
      if (err) throw err;
      console.dir(list);
      conn.end();
    });
  }, { command: '/usr/bin/sudo /usr/libexec/sftp-server' } );
}).connect({
  host: '192.168.100.100',
  port: 22,
  username: 'frylock',
  password: 'nodejsrules'
});

```

