### PR TITLE
Prevent test and examples folders from being packaged in release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+examples


### PR DESCRIPTION
Resolves https://github.com/mscdex/ssh2/issues/1217

As mentioned in the linked issue, I am also experiencing a security scan issue due to the presence of the `test` folder in the release package. As suggested in the issue, I created a `.npmignore` file to ensure that the `test` and `examples` folders are not included  in the release package.