### PR TITLE
Allow an env var to skip install.js for this package only

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,5 +1,11 @@
 'use strict';
 
+// This allows someone to disable this script for this repository only.
+// npm/yarn/pnpm only allow you to disable install scripts globally.
+if (process.env.SSH2_NODE_PURE_JS_ONLY) {
+  exit(0);
+}
+
 const { spawnSync } = require('child_process');
 
 const forceFailOnNonZero = (process.env.CI_CHECK_FAIL === 'ssh2');


### PR DESCRIPTION
This will allow us (hopefully; I have no confirmation that skipping this step results in a successful build which doesn't fail at runtime -- see #1310) to disable this install script for this package only, something that none of the major node package managers allow (couldn't find a way in any of npm/yarn/pnpm to do this for only this package -- only globally disable scripts, when `find node_modules -name package.json | wc -l` is almost 7000 files, i'm not sure how i'm ever supposed to validate that "globally disallow lifecycle scripts" doesn't break anything).

In any case, since this package claims to be "pure javascript", it should have an easy and explicit way to disable C++ modules, and actually be "pure" javascript.

But, again, I don't know if this even makes a difference. Our CI "forgot" to bundle binary modules, and this caused our production services to fail at run-time because it couldn't load this module. I'm fairly sure there is something else I need to do in this PR to disable this binary module, but I don't know what it is. To me, that means that if this script is disabled, this binary module won't appear in our codebase, and we'd get the same runtime exception thrown about not being able to load it as we did when our CI skipped adding it (because "don't copy it into the codebase" and "never generate it in the first place" SHOULD behave the same when "it doesn't exist", which is either "this is ok, i can live w/o this module" or "i fail at runtime b/c this module isn't there". For us, it is always the latter)