### PR TITLE
Allow configurable read and write packet length for SFTP

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -92,6 +92,8 @@ class Client extends EventEmitter {
       hostHashAlgo: undefined,
       hostHashCb: undefined,
       strictVendor: undefined,
+      sftpMaxReadLen: undefined,
+      sftpMaxWriteLen: undefined,
       debug: undefined
     };
 
@@ -557,7 +559,7 @@ class Client extends EventEmitter {
           };
           const instance = (
             isSFTP
-            ? new SFTP(this, chanInfo, { debug })
+            ? new SFTP(this, chanInfo, { maxReadLen: cfg.sftpMaxReadLen, maxWriteLen: cfg.sftpMaxWriteLen, debug })
             : new Channel(this, chanInfo)
           );
           this._chanMgr.update(info.recipient, instance);

--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -157,8 +157,10 @@ class SFTP extends EventEmitter {
     this._maxInPktLen = OPENSSH_MAX_PKT_LEN;
     this._maxOutPktLen = 34000;
     this._maxReadLen =
+      cfg.maxReadLen ? cfg.maxReadLen :
       (this._isOpenSSH ? OPENSSH_MAX_PKT_LEN : 34000) - PKT_RW_OVERHEAD;
     this._maxWriteLen =
+      cfg.maxWriteLen ? cfg.maxWriteLen :
       (this._isOpenSSH ? OPENSSH_MAX_PKT_LEN : 34000) - PKT_RW_OVERHEAD;
 
     this.maxOpenHandles = undefined;


### PR DESCRIPTION
While it's not a complete solution, this helps with poor throughput issues when using createReadSteam()