### PR TITLE
Allow the use of .ppk v3 files

### DIFF
--- a/lib/protocol/keyParser.js
+++ b/lib/protocol/keyParser.js
@@ -1007,7 +1007,7 @@ PPK_Private.prototype = BaseKey;
   const PPK_IV = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
   const PPK_PP1 = Buffer.from([0, 0, 0, 0]);
   const PPK_PP2 = Buffer.from([0, 0, 0, 1]);
-  const regexp = /^PuTTY-User-Key-File-2: (ssh-(?:rsa|dss))\r?\nEncryption: (aes256-cbc|none)\r?\nComment: ([^\r\n]*)\r?\nPublic-Lines: \d+\r?\n([\s\S]+?)\r?\nPrivate-Lines: \d+\r?\n([\s\S]+?)\r?\nPrivate-MAC: ([^\r\n]+)/;
+  const regexp = /^PuTTY-User-Key-File-[23]: (ssh-(?:rsa|dss))\r?\nEncryption: (aes256-cbc|none)\r?\nComment: ([^\r\n]*)\r?\nPublic-Lines: \d+\r?\n((?:[-\w+\/=]+?\n?)*)\n(?:\S+:[^\n]*\n)*\r?Private-Lines: \d+\r?\n((?:[-\w+\/=]+?\n?)*)\r?\nPrivate-MAC: ([^\r\n]+)/;
   PPK_Private.parse = (str, passphrase) => {
     const m = regexp.exec(str);
     if (m === null)


### PR DESCRIPTION
This PR allows the use of the keyParser function with a .ppk file v3 (PuTTY-User-Key-File-3) without altering the use of the v2 keys.

Fixes the issue #1140 

I had to allow more lines between the Public and Private lines as the format of the new version uses those spaces but the regex may not be optimal, feel free to optimize it.