### PR TITLE
Work better with Yarn4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nan": "^2.17.0"
   },
   "scripts": {
-    "install": "node install.js",
+    "postinstall": "node install.js",
     "rebuild": "node install.js",
     "test": "node test/test.js",
     "lint": "eslint --cache --report-unused-disable-directives --ext=.js .eslintrc.js examples lib test",


### PR DESCRIPTION
Yarn3/4 does not support automatically running the `install` or `rebuild` scripts in dependencies. You CAN configure on a granular level whether the `postinstall` is installed.

This will allow the binary modules in this library to be built by yarn3/4, and should not hurt the way this module works in `npm` or `pnpm`.