### PR TITLE
Force IPV4 on cygwin ssh-agent connections

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -378,7 +378,7 @@ const CygwinAgent = (() => {
           sock.on('error', onFail);
           sock.on('end', onFail);
           sock.on('close', onFail);
-          sock.connect(port);
+          sock.connect(port, '127.0.0.1');
         }
       });
     }


### PR DESCRIPTION
After upgrading to node18, our SSH connections from windows started failing and I determined that the failure was caused by git-for-windows' ssh-agent listening on the ipv4 loopback address while ssh2 was attempting to connect to the ipv6 loopback address and failing as a result.

The change in node18 that causes this bug is the following:
https://github.com/nodejs/node/pull/39987
which causes node to resolve addresses in the order that windows provides them rather than forcing ipv4 addresses to come first. This causes node's net implementation to use the ipv6 loopback address by default instead of the ipv4 loopback address like previously.

The unix-socket-emulation layer behind cygwin/msys2/git-for-windows binds directly to the ipv4 loopback address and doesn't appear to be able to bind to an ipv6 address:
https://github.com/git-for-windows/msys2-runtime/blob/be826601df87b13be6038bb7e23a01d92be7ef07/winsup/cygwin/fhandler/socket_local.cc#L802

We use a wrapper around ssh2 which doesn't handle this error as gracefully as modern versions of SSH2 which throw this error:
https://github.com/mscdex/ssh2/blob/739a58976ca149aa852150501f08b92bc380650a/lib/agent.js#L371
Our wrapper would instead fully crash the node process which was much harder to track down.