### PR TITLE
Fix #1118: Fix the regular expression in Protocol.js for handling ide…

### DIFF
--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -1909,7 +1909,7 @@ class Protocol {
 }
 
 // SSH-protoversion-softwareversion (SP comments) CR LF
-const RE_IDENT = /^SSH-(2\.0|1\.99)-([^ ]+)(?: (.*))?$/;
+const RE_IDENT = /^SSH-(2\.0|1\.99)-([^ ]*)(?: (.*))?$/;
 
 // TODO: optimize this by starting n bytes from the end of this._buffer instead
 // of the beginning


### PR DESCRIPTION
…nt information.

There is a scenario where some SSH servers return an ident of 'SSH-2.0-' which leads to the throwing of an 'Invalid identification string' exception. This commit addresses compatibility for this scenario.