### PR TITLE
CHORE: Add .gitattributes to enforce LF line endings over CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Add a git attributes file to enforce LF line ending instead of CRLF line endings when checking out the repository on windows devices.