### PR TITLE
Remove all non-prod files from distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssh2",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "SSH2 client and server modules written in pure JavaScript for node.js",
   "main": "./lib/index.js",
@@ -45,5 +45,8 @@
   "repository": {
     "type": "git",
     "url": "http://github.com/mscdex/ssh2.git"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
When installing `ssh2`, the tests and test fixtures are all installed. This doesn't feel desirable, as it puts test keys, example code, and other data into the runtime environment.

This change will pack only the `lib` directory, but that does include `LICENSE`, `package.json`, and `README.md` per npm. See https://docs.npmjs.com/cli/v10/using-npm/developers#keeping-files-out-of-your-package for more information.

Running `npm pack` gave me a tarball with these files:

```
package/LICENSE
package/lib/protocol/crypto/src/binding.cc
package/lib/protocol/crypto/binding.gyp
package/lib/agent.js
package/lib/Channel.js
package/lib/client.js
package/lib/protocol/constants.js
package/lib/protocol/crypto.js
package/lib/protocol/handlers.js
package/lib/protocol/handlers.misc.js
package/lib/http-agents.js
package/lib/index.js
package/lib/protocol/kex.js
package/lib/keygen.js
package/lib/protocol/keyParser.js
package/lib/protocol/node-fs-compat.js
package/lib/protocol/crypto/poly1305.js
package/lib/protocol/Protocol.js
package/lib/server.js
package/lib/protocol/SFTP.js
package/lib/protocol/utils.js
package/lib/utils.js
package/lib/protocol/zlib.js
package/package.json
package/README.md
```

Let me know if anything is missing.