### PR TITLE
feat: add SUPPORTED_* constants to module exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,12 +19,26 @@ const {
   STATUS_CODE,
   stringToFlags,
 } = require('./protocol/SFTP.js');
+const {
+  SUPPORTED_KEX,
+  SUPPORTED_SERVER_HOST_KEY,
+  SUPPORTED_CIPHER,
+  SUPPORTED_MAC,
+  SUPPORTED_COMPRESSION,
+} = require('./protocol/constants');
 
 module.exports = {
   AgentProtocol,
   BaseAgent,
   createAgent,
   Client: require('./client.js'),
+  constants: {
+    SUPPORTED_KEX,
+    SUPPORTED_SERVER_HOST_KEY,
+    SUPPORTED_CIPHER,
+    SUPPORTED_MAC,
+    SUPPORTED_COMPRESSION,
+  },
   CygwinAgent,
   HTTPAgent,
   HTTPSAgent,


### PR DESCRIPTION
It's really useful to have access to these constants when implementing some lower level integrations with the library.

For example, I want to filter out SSH keys that aren't supported.

It is possible to pull these constants out by doing `require('ssh2/lib/protocol/constants')` but it would be nice to see them given "first class" support.