### PR TITLE
ci: reduce footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "SSH2 client and server modules written in pure JavaScript for node.js",
   "main": "./lib/index.js",
+  "files": [
+    "lib",
+    "install.js"
+  ],
   "engines": {
     "node": ">=10.16.0"
   },


### PR DESCRIPTION
This will reduce your node_modules on-disk footprint from 1.8M to 884K, and your package size from 256K to 142K.

Cheers ;) 

```
 $ du -h node_modules/ssh2/
20.0K   node_modules/ssh2/examples
352.0K  node_modules/ssh2/test/fixtures/keyParser
404.0K  node_modules/ssh2/test/fixtures
612.0K  node_modules/ssh2/test
12.0K   node_modules/ssh2/.github/workflows
16.0K   node_modules/ssh2/.github
68.0K   node_modules/ssh2/lib/protocol/crypto/src
140.0K  node_modules/ssh2/lib/protocol/crypto/build/Release/obj.target/sshcrypto/src
144.0K  node_modules/ssh2/lib/protocol/crypto/build/Release/obj.target/sshcrypto
148.0K  node_modules/ssh2/lib/protocol/crypto/build/Release/obj.target
24.0K   node_modules/ssh2/lib/protocol/crypto/build/Release/.deps/Release/obj.target/sshcrypto/src
28.0K   node_modules/ssh2/lib/protocol/crypto/build/Release/.deps/Release/obj.target/sshcrypto
36.0K   node_modules/ssh2/lib/protocol/crypto/build/Release/.deps/Release/obj.target
44.0K   node_modules/ssh2/lib/protocol/crypto/build/Release/.deps/Release
48.0K   node_modules/ssh2/lib/protocol/crypto/build/Release/.deps
284.0K  node_modules/ssh2/lib/protocol/crypto/build/Release
4.0K    node_modules/ssh2/lib/protocol/crypto/build/node_gyp_bins
336.0K  node_modules/ssh2/lib/protocol/crypto/build
436.0K  node_modules/ssh2/lib/protocol/crypto
856.0K  node_modules/ssh2/lib/protocol
1.0M    node_modules/ssh2/lib
64.0K   node_modules/ssh2/util
1.8M    node_modules/ssh2/
```

and the tars:
```
$ ls -la 
-rw-r--r-- 1 osher osher 256K May  5 19:40 ssh2-1.15.0.before.tgz
-rw-r--r-- 1 osher osher 142K May  5 19:40 ssh2-1.15.0.tgz
```