### PR TITLE
fix: utils.isDate deprecated

### DIFF
--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -7,7 +7,7 @@ const {
   Readable: ReadableStream,
   Writable: WritableStream
 } = require('stream');
-const { inherits, isDate } = require('util');
+const { inherits, types: { isDate } } = require('util');
 
 const FastBuffer = Buffer[Symbol.species];
 


### PR DESCRIPTION
Node.js version 22 deprecated the `utils.isDate` function. The proposal implements the proposed official correction present in the console output `Uncaught DeprecationWarning: The `util.isDate` API is deprecated.  Please use `arg instanceof Date` instead.`.

Note, the deprecation brakes code execution when the `--throw-deprecation` flag is enabled.