### PR TITLE
Fix thread-safety issues in native bindings replacing `Nan::Persistent` with `v8::Eternal`

### DIFF
--- a/lib/protocol/crypto/src/binding.cc
+++ b/lib/protocol/crypto/src/binding.cc
@@ -84,11 +84,15 @@ class ChaChaPolyCipher : public ObjectWrap {
     SetPrototypeMethod(tpl, "encrypt", Encrypt);
     SetPrototypeMethod(tpl, "free", Free);
 
-    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Local<Function> func = Nan::GetFunction(tpl).ToLocalChecked();
+    Local<Context> context = Nan::GetCurrentContext();
+    v8::Isolate* isolate = context->GetIsolate();
+
+    constructor().Set(isolate, func);
 
     Nan::Set(target,
              Nan::New("ChaChaPolyCipher").ToLocalChecked(),
-             Nan::GetFunction(tpl).ToLocalChecked());
+             func);
   }
 
  private:
@@ -387,8 +391,8 @@ out:
     obj->clear();
   }
 
-  static inline Nan::Persistent<Function> & constructor() {
-    static Nan::Persistent<Function> my_constructor;
+  static inline v8::Eternal<v8::Function> & constructor() {
+    static v8::Eternal<v8::Function> my_constructor;
     return my_constructor;
   }
 
@@ -414,11 +418,15 @@ class AESGCMCipher : public ObjectWrap {
     SetPrototypeMethod(tpl, "encrypt", Encrypt);
     SetPrototypeMethod(tpl, "free", Free);
 
-    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Local<Function> func = Nan::GetFunction(tpl).ToLocalChecked();
+    Local<Context> context = Nan::GetCurrentContext();
+    v8::Isolate* isolate = context->GetIsolate();
+
+    constructor().Set(isolate, func);
 
     Nan::Set(target,
              Nan::New("AESGCMCipher").ToLocalChecked(),
-             Nan::GetFunction(tpl).ToLocalChecked());
+             func);
   }
 
  private:
@@ -633,8 +641,8 @@ out:
     obj->clear();
   }
 
-  static inline Nan::Persistent<Function> & constructor() {
-    static Nan::Persistent<Function> my_constructor;
+  static inline v8::Eternal<v8::Function> & constructor() {
+    static v8::Eternal<v8::Function> my_constructor;
     return my_constructor;
   }
 
@@ -651,11 +659,15 @@ class GenericCipher : public ObjectWrap {
     SetPrototypeMethod(tpl, "encrypt", Encrypt);
     SetPrototypeMethod(tpl, "free", Free);
 
-    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Local<Function> func = Nan::GetFunction(tpl).ToLocalChecked();
+    Local<Context> context = Nan::GetCurrentContext();
+    v8::Isolate* isolate = context->GetIsolate();
+
+    constructor().Set(isolate, func);
 
     Nan::Set(target,
              Nan::New("GenericCipher").ToLocalChecked(),
-             Nan::GetFunction(tpl).ToLocalChecked());
+             func);
   }
 
  private:
@@ -1014,8 +1026,8 @@ out:
     obj->clear();
   }
 
-  static inline Nan::Persistent<Function> & constructor() {
-    static Nan::Persistent<Function> my_constructor;
+  static inline v8::Eternal<v8::Function> & constructor() {
+    static v8::Eternal<v8::Function> my_constructor;
     return my_constructor;
   }
 
@@ -1044,11 +1056,15 @@ class ChaChaPolyDecipher : public ObjectWrap {
     SetPrototypeMethod(tpl, "decryptLen", DecryptLen);
     SetPrototypeMethod(tpl, "free", Free);
 
-    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Local<Function> func = Nan::GetFunction(tpl).ToLocalChecked();
+    Local<Context> context = Nan::GetCurrentContext();
+    v8::Isolate* isolate = context->GetIsolate();
+
+    constructor().Set(isolate, func);
 
     Nan::Set(target,
              Nan::New("ChaChaPolyDecipher").ToLocalChecked(),
-             Nan::GetFunction(tpl).ToLocalChecked());
+             func);
   }
 
  private:
@@ -1440,8 +1456,8 @@ out:
     obj->clear();
   }
 
-  static inline Nan::Persistent<Function> & constructor() {
-    static Nan::Persistent<Function> my_constructor;
+  static inline v8::Eternal<v8::Function> & constructor() {
+    static v8::Eternal<v8::Function> my_constructor;
     return my_constructor;
   }
 
@@ -1468,11 +1484,15 @@ class AESGCMDecipher : public ObjectWrap {
     SetPrototypeMethod(tpl, "decrypt", Decrypt);
     SetPrototypeMethod(tpl, "free", Free);
 
-    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Local<Function> func = Nan::GetFunction(tpl).ToLocalChecked();
+    Local<Context> context = Nan::GetCurrentContext();
+    v8::Isolate* isolate = context->GetIsolate();
+
+    constructor().Set(isolate, func);
 
     Nan::Set(target,
              Nan::New("AESGCMDecipher").ToLocalChecked(),
-             Nan::GetFunction(tpl).ToLocalChecked());
+             func);
   }
 
  private:
@@ -1697,8 +1717,8 @@ out:
     obj->clear();
   }
 
-  static inline Nan::Persistent<Function> & constructor() {
-    static Nan::Persistent<Function> my_constructor;
+  static inline v8::Eternal<v8::Function> & constructor() {
+    static v8::Eternal<v8::Function> my_constructor;
     return my_constructor;
   }
 
@@ -1716,11 +1736,15 @@ class GenericDecipher : public ObjectWrap {
     SetPrototypeMethod(tpl, "decrypt", Decrypt);
     SetPrototypeMethod(tpl, "free", Free);
 
-    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Local<Function> func = Nan::GetFunction(tpl).ToLocalChecked();
+    Local<Context> context = Nan::GetCurrentContext();
+    v8::Isolate* isolate = context->GetIsolate();
+
+    constructor().Set(isolate, func);
 
     Nan::Set(target,
              Nan::New("GenericDecipher").ToLocalChecked(),
-             Nan::GetFunction(tpl).ToLocalChecked());
+             func);
   }
 
  private:
@@ -2183,8 +2207,8 @@ out:
     obj->clear();
   }
 
-  static inline Nan::Persistent<Function> & constructor() {
-    static Nan::Persistent<Function> my_constructor;
+  static inline v8::Eternal<v8::Function> & constructor() {
+    static v8::Eternal<v8::Function> my_constructor;
     return my_constructor;
   }
 

--- a/test/test-worker-imports.js
+++ b/test/test-worker-imports.js
@@ -1,0 +1,19 @@
+// Test for thread-safety issues caused by subsequent imports of the module
+// in worker threads: https://github.com/mscdex/ssh2/issues/1393.
+// Each subsequent worker increases probability of abnormal termination.
+// The probability of a false pass due to zero response becomes negligible
+// for 4 consecutive workers.
+'use strict';
+
+const { Worker, isMainThread } = require('worker_threads');
+require('../lib/index.js');
+
+if (isMainThread) {
+  async function runWorker() {
+    return new Promise((r) => new Worker(__filename).on("exit", r));
+  }
+  runWorker()
+    .then(runWorker)
+    .then(runWorker)
+    .then(runWorker);
+}

--- a/test/test-worker-imports.js
+++ b/test/test-worker-imports.js
@@ -5,12 +5,18 @@
 // for 4 consecutive workers.
 'use strict';
 
-const { Worker, isMainThread } = require('worker_threads');
+let Worker, isMainThread;
+try {
+  ({ Worker, isMainThread } = require('worker_threads'));
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
+  process.exit(0);
+}
 require('../lib/index.js');
 
 if (isMainThread) {
   async function runWorker() {
-    return new Promise((r) => new Worker(__filename).on("exit", r));
+    return new Promise((r) => new Worker(__filename).on('exit', r));
   }
   runWorker()
     .then(runWorker)


### PR DESCRIPTION
This PR addresses thread-safety issues in the native bindings of the library. It replaces `Nan::Persistent` with `v8::Eternal` for constructor storage in cipher and decipher classes.

The previous implementation using `Nan::Persistent` was not thread-safe, leading to crashes and undefined behavior when these classes were accessed from multiple threads simultaneously. This was particularly problematic when ssh2 was used in multi-threaded environments, such as when imported in worker threads.

Key changes:
1. Modified the constructor method to return a `v8::Eternal` instead of a `Nan::Persistent`.
2. Updated the init function to use the `Set` method of the `Eternal` handle.

These changes ensure thread-safe storage of constructor handles without altering the intended functionality of the modules.

This PR addresses issue #1393 and resolves the reported crashes and segmentation faults related to multi-threaded use of the ssh2 library.