### PR TITLE
SFTP server example is not working

### DIFF
--- a/examples/sftp-server-download-only.js
+++ b/examples/sftp-server-download-only.js
@@ -3,7 +3,7 @@
 const { timingSafeEqual } = require('crypto');
 const { constants, readFileSync } = require('fs');
 
-const { Server, sftp: { OPEN_MODE, STATUS_CODE } } = require('ssh2');
+const { Server, utils: { sftp: { OPEN_MODE, STATUS_CODE } } } = require('ssh2');
 
 const allowedUser = Buffer.from('foo');
 const allowedPassword = Buffer.from('bar');


### PR DESCRIPTION
First off: seems like some import was refactored. I changed it in this PR.

However, there's more in here that is not working properly. When I generate a public/private keypair (`host.key` and `host.key.pub`), hardcode port 2222 (for simplicity), the server starts, and I can connect to it using `sftp` on the command line (MacOS):

```
sftp -P 2222 foo@127.0.0.1
foo@127.0.0.1's password: # type in "bar"
Connected to 127.0.0.1.
sftp> 
```

Now, when I'm trying to upload a file:

```
sftp> put foo.txt foo.txt
Uploading foo.txt to /foo.txt
dest open "/foo.txt": Failure
sftp> 
```

I also can't connect to the SFTP server using Cyberduck (a SFTP client for MacOS).