### PR TITLE
Add support for env variables with SFTP client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ You can find more examples in the `examples` directory of this repository.
 
 * **setNoDelay**([< _boolean_ >noDelay]) - _Client_ - Calls [`setNoDelay()`](https://nodejs.org/docs/latest/api/net.html#socketsetnodelaynodelay) on the underlying socket. Disabling Nagle's algorithm improves latency at the expense of lower throughput.
 
-* **sftp**(< _function_ >callback) - _(void)_ - Starts an SFTP session. `callback` has 2 parameters: < _Error_ >err, < _SFTP_ >sftp. For methods available on `sftp`, see the [`SFTP` client documentation](https://github.com/mscdex/ssh2/blob/master/SFTP.md).
+* **sftp**([< _object_ >env], < _function_ >callback) - _(void)_ - Starts an SFTP session. `env` is an environment to use when executing `sftp` methods. `callback` has 2 parameters: < _Error_ >err, < _SFTP_ >sftp. For methods available on `sftp`, see the [`SFTP` client documentation](https://github.com/mscdex/ssh2/blob/master/SFTP.md).
 
 * **shell**([[< _mixed_ >window,] < _object_ >options]< _function_ >callback) - _(void)_ - Starts an interactive shell session on the server, with an optional `window` object containing pseudo-tty settings (see 'Pseudo-TTY settings'). If `window === false`, then no pseudo-tty is allocated. `options` supports the `x11` and `env` options as described in `exec()`. `callback` has 2 parameters: < _Error_ >err, < _Channel_ >stream.
 

--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ You can find more examples in the `examples` directory of this repository.
 
 * **setNoDelay**([< _boolean_ >noDelay]) - _Client_ - Calls [`setNoDelay()`](https://nodejs.org/docs/latest/api/net.html#socketsetnodelaynodelay) on the underlying socket. Disabling Nagle's algorithm improves latency at the expense of lower throughput.
 
-* **sftp**([< _object_ >env], < _function_ >callback) - _(void)_ - Starts an SFTP session. `env` is an environment to use when executing `sftp` methods. `callback` has 2 parameters: < _Error_ >err, < _SFTP_ >sftp. For methods available on `sftp`, see the [`SFTP` client documentation](https://github.com/mscdex/ssh2/blob/master/SFTP.md).
+* **sftp**([< _object_ >env, ]< _function_ >callback) - _(void)_ - Starts an SFTP session. `env` is an environment to use when executing `sftp` methods. `callback` has 2 parameters: < _Error_ >err, < _SFTP_ >sftp. For methods available on `sftp`, see the [`SFTP` client documentation](https://github.com/mscdex/ssh2/blob/master/SFTP.md).
 
 * **shell**([[< _mixed_ >window,] < _object_ >options]< _function_ >callback) - _(void)_ - Starts an interactive shell session on the server, with an optional `window` object containing pseudo-tty settings (see 'Pseudo-TTY settings'). If `window === false`, then no pseudo-tty is allocated. `options` supports the `x11` and `env` options as described in `exec()`. `callback` has 2 parameters: < _Error_ >err, < _Channel_ >stream.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,7 +146,6 @@ class Client extends EventEmitter {
                          || Buffer.isBuffer(cfg.ident)
                          ? cfg.ident
                          : undefined);
-    this.config.sftpEnv = cfg.sftpEnv;
 
     const algorithms = {
       kex: undefined,
@@ -1553,7 +1552,7 @@ class Client extends EventEmitter {
     return this;
   }
 
-  sftp(cb) {
+  sftp(env, cb) {
     if (!this._sock || !isWritable(this._sock))
       throw new Error('Not connected');
 
@@ -1563,9 +1562,8 @@ class Client extends EventEmitter {
         return;
       }
 
-      const sftpEnv = this.config.sftpEnv;
-      if (typeof sftpEnv === 'object' && sftpEnv !== null) {
-        reqEnv(sftp, sftpEnv);
+      if (typeof env === 'object' && env !== null) {
+        reqEnv(sftp, env);
       }
 
       reqSubsystem(sftp, 'sftp', (err, sftp_) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1567,11 +1567,7 @@ class Client extends EventEmitter {
         return;
       }
 
-      if (typeof env === 'object' && env !== null) {
-        reqEnv(sftp, env);
-      }
-
-      reqSubsystem(sftp, 'sftp', (err, sftp_) => {
+      const reqSubsystemCb = (err, sftp_) => {
         if (err) {
           cb(err);
           return;
@@ -1617,7 +1613,14 @@ class Client extends EventEmitter {
             .on('close', onExit);
 
         sftp._init();
-      });
+      };
+
+      if (typeof env === 'object' && env !== null) {
+        reqEnv(sftp, env, () => reqSubsystem(sftp, 'sftp', reqSubsystemCb));
+
+      } else {
+        reqSubsystem(sftp, 'sftp', reqSubsystemCb);
+      }
     });
 
     return this;
@@ -1851,7 +1854,7 @@ function reqExec(chan, cmd, opts, cb) {
   chan._client._protocol.exec(chan.outgoing.id, cmd, true);
 }
 
-function reqEnv(chan, env) {
+function reqEnv(chan, env, cb) {
   if (chan.outgoing.state !== 'open')
     return;
 
@@ -1862,6 +1865,8 @@ function reqEnv(chan, env) {
     const val = env[key];
     chan._client._protocol.env(chan.outgoing.id, key, val, false);
   }
+
+  typeof cb === 'function' && cb();
 }
 
 function reqSubsystem(chan, name, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1556,6 +1556,11 @@ class Client extends EventEmitter {
     if (!this._sock || !isWritable(this._sock))
       throw new Error('Not connected');
 
+    if (typeof env === 'function') {
+      cb = env;
+      env = undefined;
+    }
+
     openChannel(this, 'sftp', (err, sftp) => {
       if (err) {
         cb(err);

--- a/lib/client.js
+++ b/lib/client.js
@@ -1855,18 +1855,33 @@ function reqExec(chan, cmd, opts, cb) {
 }
 
 function reqEnv(chan, env, cb) {
-  if (chan.outgoing.state !== 'open')
+  const wantReply = (typeof cb === 'function');
+
+  if (chan.outgoing.state !== 'open') {
+    if (wantReply)
+      cb(new Error('Channel is not open'));
     return;
+  }
+
+  if (wantReply) {
+    chan._callbacks.push((had_err) => {
+      if (had_err) {
+        cb(had_err !== true
+           ? had_err
+           : new Error('Unable to set env'));
+        return;
+      }
+      cb();
+    });
+  }
 
   const keys = Object.keys(env || {});
 
   for (let i = 0; i < keys.length; ++i) {
     const key = keys[i];
     const val = env[key];
-    chan._client._protocol.env(chan.outgoing.id, key, val, false);
+    chan._client._protocol.env(chan.outgoing.id, key, val, wantReply);
   }
-
-  typeof cb === 'function' && cb();
 }
 
 function reqSubsystem(chan, name, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1868,7 +1868,7 @@ function reqEnv(chan, env, cb) {
       if (had_err) {
         cb(had_err !== true
            ? had_err
-           : new Error('Unable to set env'));
+           : new Error('Unable to set environment'));
         return;
       }
       cb();

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,6 +146,7 @@ class Client extends EventEmitter {
                          || Buffer.isBuffer(cfg.ident)
                          ? cfg.ident
                          : undefined);
+    this.config.sftpEnv = cfg.sftpEnv;
 
     const algorithms = {
       kex: undefined,
@@ -1560,6 +1561,11 @@ class Client extends EventEmitter {
       if (err) {
         cb(err);
         return;
+      }
+
+      const sftpEnv = this.config.sftpEnv;
+      if (typeof sftpEnv === 'object' && sftpEnv !== null) {
+        reqEnv(sftp, sftpEnv);
       }
 
       reqSubsystem(sftp, 'sftp', (err, sftp_) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1622,8 +1622,8 @@ class Client extends EventEmitter {
             return;
           }
 
-           reqSubsystem(sftp, 'sftp', reqSubsystemCb);
-          });
+          reqSubsystem(sftp, 'sftp', reqSubsystemCb);
+        });
       } else {
         reqSubsystem(sftp, 'sftp', reqSubsystemCb);
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1616,8 +1616,14 @@ class Client extends EventEmitter {
       };
 
       if (typeof env === 'object' && env !== null) {
-        reqEnv(sftp, env, () => reqSubsystem(sftp, 'sftp', reqSubsystemCb));
+        reqEnv(sftp, env, (err) => {
+          if (err) {
+            cb(err);
+            return;
+          }
 
+           reqSubsystem(sftp, 'sftp', reqSubsystemCb);
+          });
       } else {
         reqSubsystem(sftp, 'sftp', reqSubsystemCb);
       }

--- a/test/test-sftp.js
+++ b/test/test-sftp.js
@@ -757,7 +757,7 @@ setup('WriteStream', mustCall((client, server) => {
 
 {
   const { client, server } = setup_(
-    'SFTP server sets environment and aborts with exit-status',
+    'SFTP client sets environment',
     {
       client: { username: 'foo', password: 'bar' },
       server: { hostKeys: [ fixture('ssh_host_rsa_key') ] },
@@ -776,11 +776,7 @@ setup('WriteStream', mustCall((client, server) => {
           assert(info.key === Object.keys(env)[0], 'Wrong env key');
           assert(info.val === Object.values(env)[0], 'Wrong env value');
         })).on('sftp', mustCall((accept, reject) => {
-          const sftp = accept();
-
-          // XXX: hack
-          sftp._protocol.exitStatus(sftp.outgoing.id, 127);
-          sftp._protocol.channelClose(sftp.outgoing.id);
+          accept();
         }));
       }));
     }));
@@ -790,13 +786,11 @@ setup('WriteStream', mustCall((client, server) => {
     const timeout = setTimeout(mustNotCall(), 1000);
     client.sftp(env, mustCall((err, sftp) => {
       clearTimeout(timeout);
-      assert(err, 'Expected error');
-      assert(err.code === 127, `Expected exit code 127, saw: ${err.code}`);
+      assert(!err, `Unexpected exec error: ${err}`);
       client.end();
     }));
   }));
 }
-
 
 // =============================================================================
 function setup(title, cb) {


### PR DESCRIPTION
This relates to and closes this issue: https://github.com/mscdex/ssh2/issues/1433

I basically saw how this was implemented in the exec() method in `client.js` and did a similar implementation.

I seems that it might be better to add an additional parameter to the sftp() method, i.e. in `client.js` it would appear as `sftp(env, cb)`, I wasn't entirely sure, what do you think? Thanks!