### PR TITLE
feature: Updating ssh protocol to support disconnect message and language in packet

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1176,9 +1176,10 @@ class Client extends EventEmitter {
     return this;
   }
 
-  end() {
+  end(reason = null, message = '', lang = '') {
+    reason = reason || DISCONNECT_REASON.BY_APPLICATION;
     if (this._sock && isWritable(this._sock)) {
-      this._protocol.disconnect(DISCONNECT_REASON.BY_APPLICATION);
+      this._protocol.disconnect(reason, message, lang);
       this._sock.end();
     }
     return this;

--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -321,23 +321,36 @@ class Protocol {
 
   // Global
   // ------
-  disconnect(reason) {
-    const pktLen = 1 + 4 + 4 + 4;
+  disconnect(reason, message = '', lang = '') {
+    const msgLen = Buffer.byteLength(message);
+    const langLen = Buffer.byteLength(lang);
+    const pktLen = 1 + 4 + 4 + msgLen + 4 + langLen;
     // We don't use _packetRW.write.* here because we need to make sure that
     // we always get a full packet allocated because this message can be sent
     // at any time -- even during a key exchange
     let p = this._packetRW.write.allocStartKEX;
     const packet = this._packetRW.write.alloc(pktLen, true);
-    const end = p + pktLen;
 
     if (!VALID_DISCONNECT_REASONS.has(reason))
       reason = DISCONNECT_REASON.PROTOCOL_ERROR;
 
     packet[p] = MESSAGE.DISCONNECT;
     writeUInt32BE(packet, reason, ++p);
-    packet.fill(0, p += 4, end);
+    p += 4;
 
-    this._debug && this._debug(`Outbound: Sending DISCONNECT (${reason})`);
+    writeUInt32BE(packet, msgLen, p);
+    p += 4;
+    if (msgLen > 0) {
+      packet.utf8Write(message, p, msgLen);
+      p += msgLen;
+    }
+
+    writeUInt32BE(packet, langLen, p);
+    p += 4;
+    if (langLen > 0)
+      packet.utf8Write(lang, p, langLen);
+
+    this._debug && this._debug(`Outbound: Sending DISCONNECT (${reason}, message: ${message})`);
     sendPacket(this, this._packetRW.write.finalize(packet, true), true);
   }
   ping() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1278,9 +1278,10 @@ class Client extends EventEmitter {
     }
   }
 
-  end() {
+  end(reason = null, message = '', lang = '') {
+    reason = reason || DISCONNECT_REASON.BY_APPLICATION;
     if (this._sock && isWritable(this._sock)) {
-      this._protocol.disconnect(DISCONNECT_REASON.BY_APPLICATION);
+      this._protocol.disconnect(reason, message, lang);
       this._sock.end();
     }
     return this;

--- a/test/test-misc-client-server.js
+++ b/test/test-misc-client-server.js
@@ -1458,3 +1458,34 @@ const setup = setupSimple.bind(undefined, debug);
     }));
   }));
 }
+
+{
+  const { DISCONNECT_REASON } = require('../lib/protocol/constants.js');
+  const { client, server } = setup_(
+    'Server disconnect with custom reason and message',
+    {
+      client: clientCfg,
+      server: serverCfg,
+      noClientError: true,
+    },
+  );
+
+  server.on('connection', mustCall((conn) => {
+    conn.on('authentication', mustCall((ctx) => {
+      ctx.accept();
+    })).on('ready', mustCall(() => {
+      conn.end(
+        DISCONNECT_REASON.PROTOCOL_ERROR,
+        'Too many authentication failures'
+      );
+    }));
+  }));
+
+  client.on('ready', mustCall(() => {}));
+  client.on('error', mustCall((err) => {
+    assert(err.code === DISCONNECT_REASON.PROTOCOL_ERROR,
+      `Expected reason ${DISCONNECT_REASON.PROTOCOL_ERROR}, got: ${err.code}`);
+    assert(err.message === 'Too many authentication failures',
+      `Expected custom message, got: ${err.message}`);
+  }));
+}


### PR DESCRIPTION
This allows more fine grained control of the disconnect message packet. Allowing custom authentication implementations to communicate to clients the reason for connection failure.

A common pattern that openssh implements is an  authentication failure limit. Resulting in the following message:

```
Received disconnect from 10.99.33.252 port 30372:2: Too many authentication failures
Disconnected from 10.99.33.252 port 30372
```

ssh2 js can implement this but there was no way to pass back a human readable message or change the reason to PROTOCOL_ERROR: 2 which is most appropriate for a "Too many authentication failures" message.

Fall back is set to reason: BY_APPLICATION so those who do not implement custom authentication exit patterns won't be affected.