### PR TITLE
fix when server no EXT_INFO serverSigAlgs is undefined, client return…

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2120,6 +2120,9 @@ function hostKeysProve(client, keys_, cb) {
 function getKeyAlgos(client, key, serverSigAlgs) {
   switch (key.type) {
     case 'ssh-rsa':
+      if (serverSigAlgs === undefined) {
+        return [['ssh-rsa', 'sha1']];
+      }
       if (client._protocol._compatFlags & COMPAT.IMPLY_RSA_SHA2_SIGALGS) {
         if (!Array.isArray(serverSigAlgs))
           serverSigAlgs = ['rsa-sha2-256', 'rsa-sha2-512'];


### PR DESCRIPTION
"fix: return correct algorithm when server doesn't send EXT_INFO (serverSigAlgs is undefined)
Previously, when the server didn't provide EXT_INFO (resulting in serverSigAlgs being undefined), the client incorrectly returned [['rsa-sha2-256', 'sha256']] which might not be supported by the server.  This change ensures proper handling of the undefined case to maintain compatibility with servers that don't send EXT_INFO."