### PR TITLE
Add gitignore for Node.js build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+lib/protocol/crypto/build/
+node_modules/
+package-lock.json
+


### PR DESCRIPTION
This adds a .gitignore file to prevent accidental commits of `node_modules`, native build outputs `lib/protocol/crypto/build/`, and `package-lock.json`.