### PR TITLE
Fix Huawei switch signature verification failed

### DIFF
--- a/lib/protocol/kex.js
+++ b/lib/protocol/kex.js
@@ -39,6 +39,7 @@ const {
   FastBuffer,
   sigSSHToASN1,
   writeUInt32BE,
+  convertToMpint,
 } = require('./utils.js');
 const {
   PacketReader,
@@ -511,27 +512,6 @@ function handleKexInit(self, payload) {
 }
 
 const createKeyExchange = (() => {
-  function convertToMpint(buf) {
-    let idx = 0;
-    let length = buf.length;
-    while (buf[idx] === 0x00) {
-      ++idx;
-      --length;
-    }
-    let newBuf;
-    if (buf[idx] & 0x80) {
-      newBuf = Buffer.allocUnsafe(1 + length);
-      newBuf[0] = 0;
-      buf.copy(newBuf, 1, idx);
-      buf = newBuf;
-    } else if (length !== buf.length) {
-      newBuf = Buffer.allocUnsafe(length);
-      buf.copy(newBuf, 0, idx);
-      buf = newBuf;
-    }
-    return buf;
-  }
-
   class KeyExchange {
     constructor(negotiated, protocol, remoteKexinit) {
       this._protocol = protocol;

--- a/lib/protocol/utils.js
+++ b/lib/protocol/utils.js
@@ -347,10 +347,12 @@ module.exports = {
         // Convert SSH signature parameters to ASN.1 BER values for OpenSSL
         const asnReader = new Ber.Reader(signature);
         asnReader.readSequence();
-        const r = convertToMpint(asnReader.readString(Ber.Integer, true));
-        const s = convertToMpint(asnReader.readString(Ber.Integer, true));
+        let r = asnReader.readString(Ber.Integer, true);
+        let s = asnReader.readString(Ber.Integer, true);
         if (r === null || s === null)
           return;
+        r = convertToMpint(r);
+        s = convertToMpint(s);
         const newSig = Buffer.allocUnsafe(4 + r.length + 4 + s.length);
         writeUInt32BE(newSig, r.length, 0);
         newSig.set(r, 4);

--- a/lib/protocol/utils.js
+++ b/lib/protocol/utils.js
@@ -14,6 +14,27 @@ function readUInt32BE(buf, offset) {
          + buf[offset];
 }
 
+function convertToMpint(buf) {
+  let idx = 0;
+  let length = buf.length;
+  while (buf[idx] === 0x00) {
+    ++idx;
+    --length;
+  }
+  let newBuf;
+  if (buf[idx] & 0x80) {
+    newBuf = Buffer.allocUnsafe(1 + length);
+    newBuf[0] = 0;
+    buf.copy(newBuf, 1, idx);
+    buf = newBuf;
+  } else if (length !== buf.length) {
+    newBuf = Buffer.allocUnsafe(length);
+    buf.copy(newBuf, 0, idx);
+    buf = newBuf;
+  }
+  return buf;
+}
+
 function bufferCopy(src, dest, srcStart, srcEnd, destStart) {
   if (!destStart)
     destStart = 0;
@@ -163,6 +184,7 @@ const utilBufferParser = makeBufferParser();
 module.exports = {
   bufferCopy,
   bufferSlice,
+  convertToMpint,
   FastBuffer,
   bufferFill: (buf, value, start, end) => {
     return TypedArrayFill.call(buf, value, start, end);
@@ -325,8 +347,8 @@ module.exports = {
         // Convert SSH signature parameters to ASN.1 BER values for OpenSSL
         const asnReader = new Ber.Reader(signature);
         asnReader.readSequence();
-        const r = asnReader.readString(Ber.Integer, true);
-        const s = asnReader.readString(Ber.Integer, true);
+        const r = convertToMpint(asnReader.readString(Ber.Integer, true));
+        const s = convertToMpint(asnReader.readString(Ber.Integer, true));
         if (r === null || s === null)
           return;
         const newSig = Buffer.allocUnsafe(4 + r.length + 4 + s.length);


### PR DESCRIPTION
This commit resolves the compatibility issue with Huawei switch devices, where the ECDSA signature verification was failing due to the r and s data not being properly minimized as mpint in the returned signature data.

#1472 