### PR TITLE
Include only the necessary files in the final bundle for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "SSH2 client and server modules written in pure JavaScript for node.js",
   "main": "./lib/index.js",
+  "files": [
+    "/lib"
+  ],
   "engines": {
     "node": ">=10.16.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "SSH2 client and server modules written in pure JavaScript for node.js",
   "main": "./lib/index.js",
   "files": [
-    "/lib"
+    "/lib",
+    "/install.js",
+    "/util"
   ],
   "engines": {
     "node": ">=10.16.0"


### PR DESCRIPTION
We are using this library in one of our project , but while scanning Docker images before they are deployed. This one, are shipping test fixtures that contain private keys (https://github.com/mscdex/ssh2/tree/master/test/fixtures) are blocking some of our applications from being deployed, as they disallow images containing private keys from being deployed. Scanning utilities don't discern between internal keys and test keys.