### PR TITLE
Doc: add error handling to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ conn.on('ready', () => {
       console.log('STDERR: ' + data);
     });
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.100.100',
   port: 22,
@@ -114,6 +116,8 @@ conn.on('ready', () => {
     });
     stream.end('ls -l\nexit\n');
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.100.100',
   port: 22,
@@ -168,6 +172,8 @@ conn.on('ready', () => {
       ''
     ].join('\r\n'));
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.100.100',
   port: 22,
@@ -219,6 +225,8 @@ conn.on('ready', () => {
     '',
     ''
   ].join('\r\n'));
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.100.100',
   port: 22,
@@ -259,6 +267,8 @@ conn.on('ready', () => {
       conn.end();
     });
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.100.100',
   port: 22,
@@ -307,12 +317,16 @@ conn1.on('ready', () => {
       console.log('FIRST :: forwardOut error: ' + err);
       return conn1.end();
     }
-    conn2.connect({
+    conn2.on('error', (err) => {
+      console.error(err)
+    }).connect({
       sock: stream,
       username: 'user2',
       password: 'password2',
     });
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.1.1',
   username: 'user1',
@@ -368,6 +382,8 @@ conn.on('ready', () => {
       code = exitcode;
     });
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '192.168.1.1',
   username: 'foo',
@@ -475,6 +491,8 @@ conn.on('ready', () => {
       console.log(data);
     }).write(xmlhello);
   });
+}).on('error', (err) => {
+  console.error(err)
 }).connect({
   host: '1.2.3.4',
   port: 22,


### PR DESCRIPTION
There are a slew of issues about how to handle errors, and after spending embarrasingly too long trying to figure out why my `try`/`catch` was not working, and reading  about 5 issue reports, I finally came across https://github.com/mscdex/ssh2/issues/1221 with:

> I'm not quite sure what you're asking. Just listen for the 'error' event on the client object like any normal node.js EventEmitter?

This PR updates the base examples to include error handling to keep these issues from popping up in the future.

If you would prefer there to be a separate header section specific for error handling, and for it not to be included in all examples, I can update this PR to do that instead.