### PR TITLE
Fix: windowAdjust sends after CHANNEL_CLOSE

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -277,7 +277,7 @@ function onEnd() {
 }
 
 function windowAdjust(self) {
-  if (self.outgoing.state === 'closed')
+  if (self.outgoing.state === 'closed' || self.outgoing.state === 'closing')
     return;
   const amt = MAX_WINDOW - self.incoming.window;
   if (amt <= 0)

--- a/test/test-channel-window-adjust.js
+++ b/test/test-channel-window-adjust.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const assert = require('assert');
+
+const {
+  mustCall,
+  mustNotCall,
+  setupSimple,
+} = require('./common.js');
+
+const {
+  windowAdjust,
+  MAX_WINDOW,
+} = require('../lib/Channel.js');
+
+const DEBUG = false;
+
+const setup = setupSimple.bind(undefined, DEBUG);
+
+// windowAdjust must not send after close() (outgoing.state === 'closing')
+{
+  const mockChannel = {
+    outgoing: { state: 'closing', id: 0 },
+    incoming: { window: 0 },
+    _client: {
+      _protocol: {
+        channelWindowAdjust: mustNotCall(
+          'channelWindowAdjust must not be called in closing state'
+        ),
+      },
+    },
+  };
+
+  windowAdjust(mockChannel);
+}
+
+// windowAdjust works normally in open state
+{
+  let called = false;
+  const mockChannel = {
+    outgoing: { state: 'open', id: 0 },
+    incoming: { window: 0 },
+    _client: {
+      _protocol: {
+        channelWindowAdjust: (id, amt) => {
+          called = true;
+          assert.strictEqual(id, 0);
+          assert.strictEqual(amt, MAX_WINDOW);
+        },
+      },
+    },
+  };
+
+  windowAdjust(mockChannel);
+  assert(called, 'channelWindowAdjust must be called in open state');
+}
+
+// windowAdjust must not send when outgoing.state === 'closed'
+{
+  const mockChannel = {
+    outgoing: { state: 'closed', id: 0 },
+    incoming: { window: 0 },
+    _client: {
+      _protocol: {
+        channelWindowAdjust: mustNotCall(
+          'channelWindowAdjust must not be called in closed state'
+        ),
+      },
+    },
+  };
+
+  windowAdjust(mockChannel);
+}
+
+// _read() must not trigger windowAdjust after close()
+{
+  const { client, server } = setup(
+    '_read() must not trigger windowAdjust after close()'
+  );
+
+  const COMMAND = 'test-window-adjust';
+
+  server.on('connection', mustCall((conn) => {
+    conn.on('ready', mustCall(() => {
+      conn.on('session', mustCall((accept, reject) => {
+        accept().on('exec', mustCall((accept, reject, info) => {
+          const stream = accept();
+          stream.write(Buffer.alloc(1024));
+          stream.exit(0);
+          stream.end();
+        }));
+      }));
+    }));
+  }));
+
+  client.on('ready', mustCall(() => {
+    client.exec(COMMAND, mustCall((err, stream) => {
+      assert(!err, `Unexpected exec error: ${err}`);
+
+      let windowAdjustCalledAfterClose = false;
+      const origWindowAdjust =
+        client._protocol.channelWindowAdjust.bind(client._protocol);
+
+      stream.on('close', mustCall(() => {
+        assert(!windowAdjustCalledAfterClose,
+               'channelWindowAdjust must not be called after close');
+        client.end();
+      }));
+
+      stream.once('data', () => {
+        // Monkeypatch to detect calls after close
+        client._protocol.channelWindowAdjust = (...args) => {
+          if (stream.outgoing.state === 'closing'
+              || stream.outgoing.state === 'closed') {
+            windowAdjustCalledAfterClose = true;
+          }
+          return origWindowAdjust(...args);
+        };
+
+        stream.destroy();
+
+        // Manually trigger _read to simulate a pending read callback
+        // arriving after close() has set state to 'closing'
+        if (stream.outgoing.state === 'closing') {
+          stream.incoming.window = 0;
+          stream._read(1);
+        }
+      });
+    }));
+  }));
+}


### PR DESCRIPTION
Hi,
Everything here (except this line) was written by Claude, however, I really have this problem in my project, and the solution really solves it, please consider it 🙃 

## Problem

`windowAdjust()` in `lib/Channel.js` only guards against `outgoing.state === 'closed'` but not `'closing'`. After `close()` sets the state to `'closing'` and sends `SSH_MSG_CHANNEL_CLOSE` (message type 97), a pending `_read()` callback can still invoke `windowAdjust()`, which sends `SSH_MSG_CHANNEL_WINDOW_ADJUST` (message type 93) after `SSH_MSG_CHANNEL_CLOSE`.

This violates RFC 4254 Section 5.3:

> "Once a party has sent a CHANNEL_CLOSE message, it MUST NOT send further messages for the channel."

The window between `close()` and receiving the remote's `CHANNEL_CLOSE` response leaves `outgoing.state` at `'closing'` — a state that `windowAdjust()` did not check.

## Fix

One-line change in `lib/Channel.js:280`:

```diff
-  if (self.outgoing.state === 'closed')
+  if (self.outgoing.state === 'closed' || self.outgoing.state === 'closing')
```

## Tests

`test/test-channel-window-adjust.js` contains four test cases:

1. **closing state** — Creates a mock channel with `outgoing.state = 'closing'` and verifies `windowAdjust()` does not call `channelWindowAdjust`. This is the bug reproduction: it fails without the fix and passes with it.

2. **open state (sanity check)** — Verifies `windowAdjust()` works normally when `outgoing.state = 'open'`, confirming the fix doesn't break the happy path.

3. **closed state** — Verifies the existing guard against `outgoing.state = 'closed'` still works.

4. **integration test** — Sets up a real client/server connection via `setupSimple`, executes a command, monkeypatches `channelWindowAdjust` to detect post-close calls, destroys the stream (triggering `close()` → `'closing'`), then manually invokes `_read()` to simulate a pending read callback. Asserts no window adjust was sent after close.
