### PR TITLE
Add missing comma in `sendExtInfo`

### DIFF
--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -2110,7 +2110,7 @@ function modesToBytes(modes) {
 
 function sendExtInfo(proto) {
   let serverSigAlgs =
-    'ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521'
+    'ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,'
       + 'rsa-sha2-512,rsa-sha2-256,ssh-rsa,ssh-dss';
   if (eddsaSupported)
     serverSigAlgs = `ssh-ed25519,${serverSigAlgs}`;


### PR DESCRIPTION
- Add a missing comma in the `sendExtInfo` function. With out it, `ecdsa-sha2-nistp521` and `rsa-sha2-512` are joined in an unrecognizable string, making both signature algorithms unusable.