### PR TITLE
fix(sftp): flush synchronously added requests during connection cleanup

### DIFF
--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -2721,17 +2721,18 @@ function doFatalSFTPError(sftp, msg, noDebug) {
 }
 
 function cleanupRequests(sftp) {
-  const keys = Object.keys(sftp._requests);
-  if (keys.length === 0)
-    return;
-
-  const reqs = sftp._requests;
-  sftp._requests = {};
   const err = new Error('No response from server');
-  for (let i = 0; i < keys.length; ++i) {
-    const req = reqs[keys[i]];
-    if (typeof req.cb === 'function')
-      req.cb(err);
+  while (true) {
+    const keys = Object.keys(sftp._requests);
+    if (keys.length === 0)
+      return;
+    const reqs = sftp._requests;
+    sftp._requests = {};
+    for (let i = 0; i < keys.length; ++i) {
+      const req = reqs[keys[i]];
+      if (typeof req.cb === 'function')
+        req.cb(err);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1490

  Problem

  cleanupRequests() runs once when the channel closes and calls all pending _requests callbacks with an error. However, some callbacks (notably the high-level readdir error path) synchronously register new entries in _requests via this.close(handle, cb). These new entries are never flushed — the channel is already non-readable, so push(null) and therefore cleanupRequests will not fire again. The user-supplied callback is silently dropped.

  Fix

  Replace the single-pass cleanup with a loop that keeps flushing until _requests is stably empty:

```
   function cleanupRequests(sftp) {
  -  const keys = Object.keys(sftp._requests);
  -  if (keys.length === 0)
  -    return;
  -
  -  const reqs = sftp._requests;
  -  sftp._requests = {};
  -  const err = new Error('No response from server');
  -  for (let i = 0; i < keys.length; ++i) {
  -    const req = reqs[keys[i]];
  -    if (typeof req.cb === 'function')
  -      req.cb(err);
  -  }
  +  const err = new Error('No response from server');
  +  while (true) {
  +    const keys = Object.keys(sftp._requests);
  +    if (keys.length === 0)
  +      return;
  +    const reqs = sftp._requests;
  +    sftp._requests = {};
  +    for (let i = 0; i < keys.length; ++i) {
  +      const req = reqs[keys[i]];
  +      if (typeof req.cb === 'function')
  +        req.cb(err);
  +    }
  +  }
   }
```

  The loop terminates because callback chains are finite (typical depth: readdir → close → user callback → done). The err object is created once outside the loop to avoid redundant allocations.

The "reproducer" at https://github.com/jeffrson/ssh2-missing-cb finally executes the callback in client when this patch is used.