### PR TITLE
fix: SFTP server subsystem sends exit-status and EOF before channel close

### DIFF
--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -285,6 +285,15 @@ class SFTP extends EventEmitter {
   }
   destroy() {
     if (this.outgoing.state === 'open' || this.outgoing.state === 'eof') {
+      // When running as a server, send exit-status and EOF before closing
+      // the channel. This matches OpenSSH behavior where the sftp-server
+      // process exits with code 0, triggering exit-status + EOF + close.
+      // Without this, clients like SCP/Mutagen see exit code -1.
+      if (this.server && this.outgoing.state === 'open') {
+        this._protocol.exitStatus(this.outgoing.id, 0);
+        this._protocol.channelEOF(this.outgoing.id);
+        this.outgoing.state = 'eof';
+      }
       this.outgoing.state = 'closing';
       this._protocol.channelClose(this.outgoing.id);
     }

--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -292,7 +292,6 @@ class SFTP extends EventEmitter {
       if (this.server && this.outgoing.state === 'open') {
         this._protocol.exitStatus(this.outgoing.id, 0);
         this._protocol.channelEOF(this.outgoing.id);
-        this.outgoing.state = 'eof';
       }
       this.outgoing.state = 'closing';
       this._protocol.channelClose(this.outgoing.id);

--- a/test/test-sftp.js
+++ b/test/test-sftp.js
@@ -755,6 +755,39 @@ setup('WriteStream', mustCall((client, server) => {
   }));
 }
 
+
+{
+  const { client, server } = setup_(
+    'SFTP server destroy() sends exit-status 0',
+    {
+      client: { username: 'foo', password: 'bar' },
+      server: { hostKeys: [ fixture('ssh_host_rsa_key') ] },
+    },
+  );
+
+  server.on('connection', mustCall((conn) => {
+    conn.on('authentication', mustCall((ctx) => {
+      ctx.accept();
+    })).on('ready', mustCall(() => {
+      conn.on('session', mustCall((accept, reject) => {
+        accept().on('sftp', mustCall((accept, reject) => {
+          const sftp = accept();
+          sftp.destroy();
+        }));
+      }));
+    }));
+  }));
+
+  client.on('ready', mustCall(() => {
+    const timeout = setTimeout(mustNotCall(), 1000);
+    client.sftp(mustCall((err, sftp) => {
+      clearTimeout(timeout);
+      assert(err, 'Expected error');
+      assert(err.code === 0, `Expected exit code 0, saw: ${err.code}`);
+      client.end();
+    }));
+  }));
+}
 {
   const { client, server } = setup_(
     'SFTP client sets environment',


### PR DESCRIPTION
### Problem
When using ssh2 as an SSH server, the server-side SFTP class's destroy() method sends channelClose without first sending exit-status or channelEOF. This causes SCP clients to report exit code -1 (or 0xffffffff), even when the SFTP transfer completes successfully.

Modern OpenSSH's scp uses the SFTP subsystem by default (since OpenSSH 9.0), so this affects any SCP operation through an ssh2-based server.

### Root Cause
The SFTP class extends EventEmitter, not Channel. The Channel class handles exit-status properly via its onFinish handler (which calls eof() then close()), but SFTP.destroy() skips straight to channelClose:
```
// Before
destroy() {
    if (this.outgoing.state === 'open' || this.outgoing.state === 'eof') {
      this.outgoing.state = 'closing';
      this._protocol.channelClose(this.outgoing.id);
    }
}
```
In contrast, OpenSSH's sftp-server process exits with code 0 when done, which causes the server to send exit-status(0) → SSH_MSG_CHANNEL_EOF → SSH_MSG_CHANNEL_CLOSE on the channel.

### Fix
When running in server mode, send exitStatus(0) and channelEOF before channelClose in destroy():
```
destroy() {
    if (this.outgoing.state === 'open' || this.outgoing.state === 'eof') {
      if (this.server && this.outgoing.state === 'open') {
        this._protocol.exitStatus(this.outgoing.id, 0);
        this._protocol.channelEOF(this.outgoing.id);
      }
      this.outgoing.state = 'closing';
      this._protocol.channelClose(this.outgoing.id);
    }
}
```
### Testing
Verified with:
- scp (SFTP mode, default) — now returns exit code 0 instead of -1
- scp -O (legacy mode, uses exec) — unaffected, still works
- Mutagen file sync agent auto-install via SCP — now succeeds without manual agent installation
- Normal SFTP file operations (read, write, mkdir, stat, etc.) — unaffected