### PR TITLE
fix(sftp): pass original position to read() callback instead of internal cursorRead overflow cb position

### DIFF
--- a/lib/protocol/SFTP.js
+++ b/lib/protocol/SFTP.js
@@ -2136,6 +2136,7 @@ function read_(self, handle, buf, off, len, position, cb, req_) {
   const req = (req_ || {
     nb: 0,
     position,
+    origPosition: position,
     off,
     origOff: off,
     len: undefined,
@@ -2162,7 +2163,7 @@ function read_(self, handle, buf, off, len, position, cb, req_) {
         data = buf;
       else
         data = bufferSlice(buf, req.origOff, req.origOff + req.nb + nb);
-      cb(undefined, req.nb + nb, data, req.position);
+      cb(undefined, req.nb + nb, data, req.origPosition);
     },
     buffer: undefined,
   });

--- a/test/test-sftp.js
+++ b/test/test-sftp.js
@@ -105,10 +105,12 @@ setup('read (overflow)', mustCall((client, server) => {
     if (reqs === 3)
       server.end();
   }, 3));
-  client.read(handle_, buf, 0, buf.length, 0, mustCall((err, nb) => {
+  const reqPos = 0
+  client.read(handle_, buf, 0, buf.length, reqPos, mustCall((err, nb, _retBuf, retPos) => {
     assert(!err, `Unexpected read() error: ${err}`);
     assert.deepStrictEqual(buf, expected);
     assert.strictEqual(nb, buf.length, 'read nb mismatch');
+    assert.strictEqual(reqPos, retPos, 'read ressource position does not match request');
   }));
 }));
 


### PR DESCRIPTION
Fixes https://github.com/mscdex/ssh2/issues/1488
(I'm sorry - this is the same as https://github.com/mscdex/ssh2/pull/1489, but I had to change branches and so it was closed automatically by Github)

Problem

sftp.read(handle, buf, off, len, position, cb) passes the wrong value as the position argument to cb when len exceeds _maxReadLen. The internal field req.position is used both as a mutable cursor for sequential sub-reads and as the return value for the user callback — so the callback always receives the end-offset of the last sub-read instead of the original position.

Fix

Introduce req.origPosition to preserve the original value across sub-reads, analogous to the existing req.origOff pattern for the off argument.

Diff

     const req = (req_ || {
       nb: 0,
       position,
  +    origPosition: position,
       off,
       origOff: off,
       ...
       cb: (err, data, nb) => {
         ...
  -      cb(undefined, req.nb + nb, data, req.position);
  +      cb(undefined, req.nb + nb, data, req.origPosition);
       },
     });
Testing

Triggers reliably with any non-OpenSSH server and a read request > 31952 bytes
With OpenSSH servers the same bug occurs for requests > 260096 bytes (~254 KB)
Prior art

This was previously reported as part of https://github.com/mscdex/ssh2/pull/1171 (attached to a different bug). The PR also contains a test case demonstrating the failure.
And of course, as mentioned previously, it is the same as https://github.com/mscdex/ssh2/pull/1489